### PR TITLE
Performance improvements

### DIFF
--- a/benchmarks/src/main/scala/io/github/vigoo/desert/benchmarks/LargeCompressedArraySerializationBenchmark.scala
+++ b/benchmarks/src/main/scala/io/github/vigoo/desert/benchmarks/LargeCompressedArraySerializationBenchmark.scala
@@ -18,6 +18,7 @@ import org.openjdk.jmh.annotations.{
 }
 import io.github.vigoo.desert._
 import io.github.vigoo.desert.custom.{readCompressedByteArray, writeCompressedBytes}
+import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
 
 import scala.io.Source
 
@@ -67,8 +68,13 @@ object LargeCompressedArraySerializationBenchmark {
   case class TestData(data: String, level: Int)
 
   object TestData {
-    implicit val binaryCodec: BinaryCodec[TestData] = BinaryCodec.define((data: TestData) =>
-      writeCompressedBytes(data.data.getBytes(StandardCharsets.UTF_8), data.level)
-    )(readCompressedByteArray().map(bytes => TestData(new String(bytes, StandardCharsets.UTF_8), Deflater.BEST_SPEED)))
+    implicit val binaryCodec: BinaryCodec[TestData] =
+      new BinaryCodec[TestData] {
+        override def deserialize()(implicit ctx: DeserializationContext): TestData =
+          TestData(new String(readCompressedByteArray(), StandardCharsets.UTF_8), Deflater.BEST_SPEED)
+
+        override def serialize(value: TestData)(implicit context: SerializationContext): Unit =
+          writeCompressedBytes(value.data.getBytes(StandardCharsets.UTF_8), value.level)
+      }
   }
 }

--- a/benchmarks/src/main/scala/io/github/vigoo/desert/benchmarks/LargeCompressedArraySerializationBenchmark.scala
+++ b/benchmarks/src/main/scala/io/github/vigoo/desert/benchmarks/LargeCompressedArraySerializationBenchmark.scala
@@ -17,8 +17,12 @@ import org.openjdk.jmh.annotations.{
   Warmup
 }
 import io.github.vigoo.desert._
-import io.github.vigoo.desert.custom.{readCompressedByteArray, writeCompressedBytes}
-import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
+import io.github.vigoo.desert.custom.{
+  DeserializationContext,
+  SerializationContext,
+  readCompressedByteArray,
+  writeCompressedBytes
+}
 
 import scala.io.Source
 

--- a/build.sbt
+++ b/build.sbt
@@ -218,7 +218,7 @@ lazy val benchmarks = project
     crossScalaVersions -= scala3
   )
   .enablePlugins(JmhPlugin)
-  .dependsOn(core.jvm, shapeless.jvm)
+  .dependsOn(core.jvm, shapeless.jvm, zioSchema.jvm)
 
 lazy val docsPlugins = project
   .in(file("docs-plugins"))

--- a/desert-cats/src/main/scala/io/github/vigoo/desert/catssupport/codecs.scala
+++ b/desert-cats/src/main/scala/io/github/vigoo/desert/catssupport/codecs.scala
@@ -3,7 +3,6 @@ package io.github.vigoo.desert
 import cats.Order
 import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet, Validated}
 import io.github.vigoo.desert.custom._
-import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
 
 package object catssupport {
   // Cats specific codecs

--- a/desert-core/src/main/scala/io/github/vigoo/desert/BinaryCodec.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/BinaryCodec.scala
@@ -2,7 +2,6 @@ package io.github.vigoo.desert
 
 import io.github.vigoo.desert.custom._
 import io.github.vigoo.desert.custom.pure.{Deser, Ser}
-import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
 
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}

--- a/desert-core/src/main/scala/io/github/vigoo/desert/BinaryCodec.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/BinaryCodec.scala
@@ -1,30 +1,72 @@
 package io.github.vigoo.desert
 
 import io.github.vigoo.desert.custom._
+import io.github.vigoo.desert.custom.pure.{Deser, Ser}
+import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
 
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
 trait BinarySerializer[T] { self =>
-  def serialize(value: T): Ser[Unit]
+  def serialize(value: T)(implicit context: SerializationContext): Unit
 
-  def contramap[U](f: U => T): BinarySerializer[U] = (value: U) => self.serialize(f(value))
+  def contramap[U](f: U => T): BinarySerializer[U] = new BinarySerializer[U] {
+    override def serialize(value: U)(implicit context: SerializationContext): Unit =
+      self.serialize(f(value))
+  }
 
-  def contramapOrFail[U](f: U => Either[DesertFailure, T]): BinarySerializer[U] = (value: U) =>
-    f(value) match {
-      case Left(value)  => failSerializerWith(value)
-      case Right(value) => self.serialize(value)
+  def contramapOrFail[U](f: U => Either[DesertFailure, T]): BinarySerializer[U] =
+    new BinarySerializer[U] {
+      override def serialize(value: U)(implicit context: SerializationContext): Unit =
+        f(value) match {
+          case Left(failure) => failSerializerWith(failure)
+          case Right(value)  => self.serialize(value)
+        }
     }
 }
 
-trait BinaryDeserializer[T] { self =>
+object BinarySerializer {
+  def fromPure[T](serializer: T => Ser[T]): BinarySerializer[T] =
+    new BinarySerializer[T] {
+      override def serialize(value: T)(implicit ctx: SerializationContext): Unit =
+        serializer(value).either.provideService(ctx.env).run(ctx.state.toPure) match {
+          case (_, Left(failure))      => throw DesertException(failure)
+          case (resultState, Right(_)) => ctx.state.resetTo(resultState)
+        }
+    }
+}
 
-  def deserialize(): Deser[T]
+trait BinaryDeserializer[T] {
+  self =>
 
-  def map[U](f: T => U): BinaryDeserializer[U] = () => self.deserialize().map(f)
+  def deserialize()(implicit ctx: DeserializationContext): T
 
-  def mapOrFail[U](f: T => Either[DesertFailure, U]): BinaryDeserializer[U] = () =>
-    self.deserialize().flatMap(value => Deser.fromEither(f(value)))
+  def map[U](f: T => U): BinaryDeserializer[U] = new BinaryDeserializer[U] {
+    override def deserialize()(implicit ctx: DeserializationContext): U =
+      f(self.deserialize())
+  }
+
+  def mapOrFail[U](f: T => Either[DesertFailure, U]): BinaryDeserializer[U] =
+    new BinaryDeserializer[U] {
+      override def deserialize()(implicit ctx: DeserializationContext): U =
+        f(self.deserialize()) match {
+          case Left(failure) => throw DesertException(failure)
+          case Right(value)  => value
+        }
+    }
+}
+
+object BinaryDeserializer {
+  def fromPure[T](deserializer: Deser[T]): BinaryDeserializer[T] =
+    new BinaryDeserializer[T] {
+      override def deserialize()(implicit ctx: DeserializationContext): T =
+        deserializer.either.provideService(ctx.env).run(ctx.state.toPure) match {
+          case (_, Left(failure))          => throw DesertException(failure)
+          case (resultState, Right(value)) =>
+            ctx.state.resetTo(resultState)
+            value
+        }
+    }
 }
 
 trait BinaryCodec[T] extends BinarySerializer[T] with BinaryDeserializer[T]
@@ -34,25 +76,27 @@ object BinaryCodec {
 
   implicit def from[T](serializer: BinarySerializer[T], deserializer: BinaryDeserializer[T]): BinaryCodec[T] =
     new BinaryCodec[T] {
-      override def deserialize(): Deser[T]        = deserializer.deserialize()
-      override def serialize(value: T): Ser[Unit] = serializer.serialize(value)
+      override def deserialize()(implicit ctx: DeserializationContext): T =
+        deserializer.deserialize()
+
+      override def serialize(value: T)(implicit context: SerializationContext): Unit =
+        serializer.serialize(value)
     }
 
-  def define[T](serializeFn: T => Ser[Unit])(deserializeFn: Deser[T]): BinaryCodec[T] = new BinaryCodec[T] {
-    override def serialize(value: T): Ser[Unit] = serializeFn(value)
-    override def deserialize(): Deser[T]        = deserializeFn
-  }
-
   def unknown[T](implicit tag: ClassTag[T]): BinaryCodec[T] =
-    define[T](
-      writeUnknown
-    )(
-      readUnknown().flatMap { value =>
+    new BinaryCodec[T] {
+      override def serialize(value: T)(implicit context: SerializationContext): Unit =
+        writeUnknown(value)
+
+      override def deserialize()(implicit context: DeserializationContext): T = {
+        val value = readUnknown()
         Try(value.asInstanceOf[T]) match {
-          case Success(upcasted)  => finishDeserializerWith(upcasted)
+          case Success(upcasted)  => upcasted
           case Failure(exception) =>
-            failDeserializerWith(DesertFailure.SerializationUpcastError(value.getClass, tag.runtimeClass, exception))
+            throw DesertException(
+              DesertFailure.SerializationUpcastError(value.getClass, tag.runtimeClass, exception)
+            )
         }
       }
-    )
+    }
 }

--- a/desert-core/src/main/scala/io/github/vigoo/desert/BinarySerialization.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/BinarySerialization.scala
@@ -2,11 +2,9 @@ package io.github.vigoo.desert
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
 import io.github.vigoo.desert.internal.{
-  DeserializationContext,
   DeserializationEnv,
   JavaStreamBinaryInput,
   JavaStreamBinaryOutput,
-  SerializationContext,
   SerializationEnv,
   SerializerState
 }
@@ -19,7 +17,7 @@ trait BinarySerialization {
       typeRegistry: TypeRegistry = TypeRegistry.empty
   ): Either[DesertFailure, Unit] = {
     implicit val ctx: SerializationContext =
-      SerializationContext(SerializationEnv(output, typeRegistry), SerializerState.create)
+      custom.SerializationContext(SerializationEnv(output, typeRegistry), SerializerState.create)
     try
       Right(write(value))
     catch {
@@ -33,7 +31,7 @@ trait BinarySerialization {
       typeRegistry: TypeRegistry = TypeRegistry.empty
   ): Either[DesertFailure, Unit] = {
     implicit val ctx: SerializationContext =
-      SerializationContext(SerializationEnv(output, typeRegistry), SerializerState.create)
+      custom.SerializationContext(SerializationEnv(output, typeRegistry), SerializerState.create)
     try
       Right(writeUnknown(value))
     catch {
@@ -46,7 +44,7 @@ trait BinarySerialization {
       typeRegistry: TypeRegistry = TypeRegistry.empty
   ): Either[DesertFailure, T] = {
     implicit val ctx: DeserializationContext =
-      DeserializationContext(DeserializationEnv(input, typeRegistry), SerializerState.create)
+      custom.DeserializationContext(DeserializationEnv(input, typeRegistry), SerializerState.create)
     try
       Right(read())
     catch {
@@ -59,7 +57,7 @@ trait BinarySerialization {
       typeRegistry: TypeRegistry = TypeRegistry.empty
   ): Either[DesertFailure, Any] = {
     implicit val ctx: DeserializationContext =
-      DeserializationContext(DeserializationEnv(input, typeRegistry), SerializerState.create)
+      custom.DeserializationContext(DeserializationEnv(input, typeRegistry), SerializerState.create)
     try
       Right(readUnknown())
     catch {

--- a/desert-core/src/main/scala/io/github/vigoo/desert/BinarySerialization.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/BinarySerialization.scala
@@ -2,9 +2,11 @@ package io.github.vigoo.desert
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
 import io.github.vigoo.desert.internal.{
+  DeserializationContext,
   DeserializationEnv,
   JavaStreamBinaryInput,
   JavaStreamBinaryOutput,
+  SerializationContext,
   SerializationEnv,
   SerializerState
 }
@@ -15,39 +17,55 @@ trait BinarySerialization {
       value: T,
       output: BinaryOutput,
       typeRegistry: TypeRegistry = TypeRegistry.empty
-  ): Either[DesertFailure, Unit] =
-    write[T](value)
-      .provideService(SerializationEnv(output, typeRegistry))
-      .either
-      .runResult(SerializerState.initial)
+  ): Either[DesertFailure, Unit] = {
+    implicit val ctx: SerializationContext =
+      SerializationContext(SerializationEnv(output, typeRegistry), SerializerState.create)
+    try
+      Right(write(value))
+    catch {
+      case DesertException(e) => Left(e)
+    }
+  }
 
   def serializeUnknown(
       value: Any,
       output: BinaryOutput,
       typeRegistry: TypeRegistry = TypeRegistry.empty
-  ): Either[DesertFailure, Unit] =
-    writeUnknown(value)
-      .provideService(SerializationEnv(output, typeRegistry))
-      .either
-      .runResult(SerializerState.initial)
+  ): Either[DesertFailure, Unit] = {
+    implicit val ctx: SerializationContext =
+      SerializationContext(SerializationEnv(output, typeRegistry), SerializerState.create)
+    try
+      Right(writeUnknown(value))
+    catch {
+      case DesertException(e) => Left(e)
+    }
+  }
 
   def deserialize[T: BinaryDeserializer](
       input: BinaryInput,
       typeRegistry: TypeRegistry = TypeRegistry.empty
-  ): Either[DesertFailure, T] =
-    read[T]()
-      .provideService(DeserializationEnv(input, typeRegistry))
-      .either
-      .runResult(SerializerState.initial)
+  ): Either[DesertFailure, T] = {
+    implicit val ctx: DeserializationContext =
+      DeserializationContext(DeserializationEnv(input, typeRegistry), SerializerState.create)
+    try
+      Right(read())
+    catch {
+      case DesertException(e) => Left(e)
+    }
+  }
 
   def deserializeUnknown(
       input: BinaryInput,
       typeRegistry: TypeRegistry = TypeRegistry.empty
-  ): Either[DesertFailure, Any] =
-    readUnknown()
-      .provideService(DeserializationEnv(input, typeRegistry))
-      .either
-      .runResult(SerializerState.initial)
+  ): Either[DesertFailure, Any] = {
+    implicit val ctx: DeserializationContext =
+      DeserializationContext(DeserializationEnv(input, typeRegistry), SerializerState.create)
+    try
+      Right(readUnknown())
+    catch {
+      case DesertException(e) => Left(e)
+    }
+  }
 
   def serializeToStream[T: BinarySerializer](
       value: T,

--- a/desert-core/src/main/scala/io/github/vigoo/desert/Codecs.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/Codecs.scala
@@ -6,35 +6,73 @@ import io.github.vigoo.desert.custom._
 import io.github.vigoo.desert.internal.SerializerState.{StringAlreadyStored, StringId, StringIsNew}
 import _root_.zio.{Chunk, NonEmptyChunk}
 import _root_.zio.prelude.{Associative, NonEmptyList, Validation, ZSet}
-import io.github.vigoo.desert.internal.AdtCodec
+import io.github.vigoo.desert.internal.{AdtCodec, DeserializationContext, OptionBinaryCodec, SerializationContext}
 
 import java.time._
+import scala.annotation.tailrec
 import scala.collection.{Factory, mutable}
 import scala.collection.immutable.{ArraySeq, SortedMap, SortedSet}
 import scala.reflect.ClassTag
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 /** Module containing implicit binary codecs for a lot of base types
   */
 trait Codecs extends internal.TupleCodecs {
 
-  implicit val byteCodec: BinaryCodec[Byte]     = BinaryCodec.define[Byte](value => writeByte(value))(readByte())
-  implicit val shortCodec: BinaryCodec[Short]   = BinaryCodec.define[Short](value => writeShort(value))(readShort())
-  implicit val intCodec: BinaryCodec[Int]       = BinaryCodec.define[Int](value => writeInt(value))(readInt())
-  implicit val longCodec: BinaryCodec[Long]     = BinaryCodec.define[Long](value => writeLong(value))(readLong())
-  implicit val floatCodec: BinaryCodec[Float]   = BinaryCodec.define[Float](value => writeFloat(value))(readFloat())
-  implicit val doubleCodec: BinaryCodec[Double] = BinaryCodec.define[Double](value => writeDouble(value))(readDouble())
+  implicit val byteCodec: BinaryCodec[Byte] = new BinaryCodec[Byte] {
+    override def deserialize()(implicit ctx: DeserializationContext): Byte            = readByte()
+    override def serialize(value: Byte)(implicit context: SerializationContext): Unit = writeByte(value)
+  }
 
-  private def createVarIntCodec(optimizeForPositive: Boolean): BinaryCodec[Int] =
-    BinaryCodec.define[Int](value => writeVarInt(value, optimizeForPositive))(readVarInt(optimizeForPositive))
-  val varIntOptimizedForPositiveCodec: BinaryCodec[Int]                         = createVarIntCodec(optimizeForPositive = true)
-  val varIntCodec: BinaryCodec[Int]                                             = createVarIntCodec(optimizeForPositive = false)
+  implicit val shortCodec: BinaryCodec[Short] = new BinaryCodec[Short] {
+    override def deserialize()(implicit ctx: DeserializationContext): Short            = readShort()
+    override def serialize(value: Short)(implicit context: SerializationContext): Unit = writeShort(value)
+  }
 
-  implicit val booleanCodec: BinaryCodec[Boolean] =
-    BinaryCodec.define[Boolean](value => writeByte(if (value) 1 else 0))(readByte().map(_ != 0))
+  implicit val intCodec: BinaryCodec[Int] = new BinaryCodec[Int] {
+    override def deserialize()(implicit ctx: DeserializationContext): Int            = readInt()
+    override def serialize(value: Int)(implicit context: SerializationContext): Unit = writeInt(value)
+  }
 
-  implicit val unitCodec: BinaryCodec[Unit] =
-    BinaryCodec.define[Unit](_ => finishSerializer())(finishDeserializerWith(()))
+  implicit val longCodec: BinaryCodec[Long] = new BinaryCodec[Long] {
+    override def deserialize()(implicit ctx: DeserializationContext): Long            = readLong()
+    override def serialize(value: Long)(implicit context: SerializationContext): Unit = writeLong(value)
+  }
+
+  implicit val floatCodec: BinaryCodec[Float] = new BinaryCodec[Float] {
+    override def deserialize()(implicit ctx: DeserializationContext): Float            = readFloat()
+    override def serialize(value: Float)(implicit context: SerializationContext): Unit = writeFloat(value)
+  }
+
+  implicit val doubleCodec: BinaryCodec[Double] = new BinaryCodec[Double] {
+    override def deserialize()(implicit ctx: DeserializationContext): Double            = readDouble()
+    override def serialize(value: Double)(implicit context: SerializationContext): Unit = writeDouble(value)
+  }
+
+  private def createVarIntCodec(optimizeForPositive: Boolean): BinaryCodec[Int] = new BinaryCodec[Int] {
+    override def deserialize()(implicit ctx: DeserializationContext): Int            =
+      readVarInt(optimizeForPositive)
+    override def serialize(value: Int)(implicit context: SerializationContext): Unit =
+      writeVarInt(value, optimizeForPositive)
+  }
+
+  val varIntOptimizedForPositiveCodec: BinaryCodec[Int] = createVarIntCodec(optimizeForPositive = true)
+  val varIntCodec: BinaryCodec[Int]                     = createVarIntCodec(optimizeForPositive = false)
+
+  implicit val booleanCodec: BinaryCodec[Boolean] = new BinaryCodec[Boolean] {
+    override def deserialize()(implicit ctx: DeserializationContext): Boolean =
+      readByte() != 0
+
+    override def serialize(value: Boolean)(implicit context: SerializationContext): Unit = writeByte(
+      if (value) 1 else 0
+    )
+  }
+
+  implicit val unitCodec: BinaryCodec[Unit] = new BinaryCodec[Unit] {
+    override def deserialize()(implicit ctx: DeserializationContext): Unit            = ()
+    override def serialize(value: Unit)(implicit context: SerializationContext): Unit = ()
+  }
 
   implicit val charCodec: BinaryCodec[Char] = BinaryCodec.from(
     shortCodec.contramap(_.toShort),
@@ -44,69 +82,70 @@ trait Codecs extends internal.TupleCodecs {
   implicit val stringCodec: BinaryCodec[String] = new BinaryCodec[String] {
     private val charset = StandardCharsets.UTF_8
 
-    override def serialize(value: String): io.github.vigoo.desert.Ser[Unit] = {
-      val raw = value.getBytes(charset)
-      for {
-        _ <- writeVarInt(raw.size, optimizeForPositive = false)
-        _ <- writeBytes(raw)
-      } yield ()
+    override def deserialize()(implicit ctx: DeserializationContext): String = {
+      val count = readVarInt(optimizeForPositive = false)
+      val bytes = readBytes(count)
+      try
+        new String(bytes, charset)
+      catch {
+        case NonFatal(reason) =>
+          throw DesertException(DesertFailure.DeserializationFailure("Failed to decode string", Some(reason)))
+      }
     }
 
-    override def deserialize(): Deser[String] =
-      for {
-        count  <- readVarInt(optimizeForPositive = false)
-        bytes  <- readBytes(count)
-        string <- Deser.fromEither(
-                    Try(new String(bytes, charset)).toEither.left.map(reason =>
-                      DesertFailure.DeserializationFailure("Failed to decode string", Some(reason))
-                    )
-                  )
-      } yield string
+    override def serialize(value: String)(implicit context: SerializationContext): Unit = {
+      val raw = value.getBytes(charset)
+      writeVarInt(raw.size, optimizeForPositive = false)
+      writeBytes(raw)
+    }
   }
 
   implicit val deduplicatedStringCodec: BinaryCodec[DeduplicatedString] = new BinaryCodec[DeduplicatedString] {
     private val charset = StandardCharsets.UTF_8
 
-    override def serialize(value: DeduplicatedString): io.github.vigoo.desert.Ser[Unit] =
-      storeString(value.string).flatMap {
+    override def deserialize()(implicit ctx: DeserializationContext): DeduplicatedString = {
+      val countOrId = readVarInt(optimizeForPositive = false)
+      if (countOrId < 0) {
+        val id = StringId(-countOrId)
+        getString(id) match {
+          case Some(string) => DeduplicatedString(string)
+          case None         => throw DesertException(DesertFailure.InvalidStringId(id))
+        }
+      } else {
+        val bytes  = readBytes(countOrId)
+        val string =
+          try
+            new String(bytes, charset)
+          catch {
+            case NonFatal(reason) =>
+              throw DesertException(DesertFailure.DeserializationFailure("Failed to decode string", Some(reason)))
+          }
+        storeReadString(string)
+        DeduplicatedString(string)
+      }
+    }
+
+    override def serialize(value: DeduplicatedString)(implicit context: SerializationContext): Unit =
+      storeString(value.string) match {
         case StringAlreadyStored(id) =>
           writeVarInt(-id.value, optimizeForPositive = false)
         case StringIsNew(id)         =>
           stringCodec.serialize(value.string)
       }
-
-    override def deserialize(): Deser[DeduplicatedString] =
-      for {
-        countOrId <- readVarInt(optimizeForPositive = false)
-        result    <- if (countOrId < 0) {
-                       val id = StringId(-countOrId)
-                       getString(id).flatMap {
-                         case Some(string) => finishDeserializerWith[String](string)
-                         case None         => failDeserializerWith[String](DesertFailure.InvalidStringId(id))
-                       }
-                     } else {
-                       for {
-                         bytes  <- readBytes(countOrId)
-                         string <- Deser.fromEither(
-                                     Try(new String(bytes, charset)).toEither.left.map(reason =>
-                                       DesertFailure.DeserializationFailure("Failed to decode string", Some(reason))
-                                     )
-                                   )
-                         _      <- storeReadString(string)
-                       } yield string
-                     }
-      } yield DeduplicatedString(result)
   }
 
-  implicit val uuidCodec: BinaryCodec[UUID] = BinaryCodec.define((uuid: UUID) =>
-    for {
-      _ <- writeLong(uuid.getMostSignificantBits)
-      _ <- writeLong(uuid.getLeastSignificantBits)
-    } yield ()
-  )(for {
-    msb <- readLong()
-    lsb <- readLong()
-  } yield new UUID(msb, lsb))
+  implicit val uuidCodec: BinaryCodec[UUID] = new BinaryCodec[UUID] {
+    override def deserialize()(implicit ctx: DeserializationContext): UUID = {
+      val mostSigBits  = readLong()
+      val leastSigBits = readLong()
+      new UUID(mostSigBits, leastSigBits)
+    }
+
+    override def serialize(value: UUID)(implicit context: SerializationContext): Unit = {
+      writeLong(value.getMostSignificantBits)
+      writeLong(value.getLeastSignificantBits)
+    }
+  }
 
   implicit val bigDecimalCodec: BinaryCodec[BigDecimal] =
     BinaryCodec.from(stringCodec.contramap(_.toString()), stringCodec.map(BigDecimal(_)))
@@ -114,19 +153,19 @@ trait Codecs extends internal.TupleCodecs {
   implicit val javaBigDecimalCodec: BinaryCodec[java.math.BigDecimal] =
     BinaryCodec.from(stringCodec.contramap(_.toString()), stringCodec.map(new java.math.BigDecimal(_)))
 
-  implicit val javaBigIntegerCodec: BinaryCodec[java.math.BigInteger] =
-    BinaryCodec.define({ (bigint: java.math.BigInteger) =>
-      val array = bigint.toByteArray
-      for {
-        _ <- writeVarInt(array.length, optimizeForPositive = true)
-        _ <- writeBytes(array)
-      } yield ()
-    })(
-      for {
-        length <- readVarInt(optimizeForPositive = true)
-        bytes  <- readBytes(length)
-      } yield new java.math.BigInteger(bytes)
-    )
+  implicit val javaBigIntegerCodec: BinaryCodec[java.math.BigInteger] = new BinaryCodec[java.math.BigInteger] {
+    override def deserialize()(implicit ctx: DeserializationContext): java.math.BigInteger = {
+      val length = readVarInt(optimizeForPositive = true)
+      val bytes  = readBytes(length)
+      new java.math.BigInteger(bytes)
+    }
+
+    override def serialize(value: java.math.BigInteger)(implicit context: SerializationContext): Unit = {
+      val bytes = value.toByteArray
+      writeVarInt(bytes.length, optimizeForPositive = true)
+      writeBytes(bytes)
+    }
+  }
 
   implicit val bigIntCodec: BinaryCodec[BigInt] =
     BinaryCodec.from(
@@ -153,64 +192,69 @@ trait Codecs extends internal.TupleCodecs {
     )
 
   implicit val monthDayCodec: BinaryCodec[MonthDay] =
-    BinaryCodec.define((monthDay: MonthDay) =>
-      for {
-        _ <- write(monthDay.getMonth)
-        _ <- writeByte(monthDay.getDayOfMonth.toByte)
-      } yield ()
-    )(for {
-      month      <- read[Month]()
-      dayOfMonth <- readByte()
-    } yield MonthDay.of(month, dayOfMonth.toInt))
+    new BinaryCodec[MonthDay] {
+      override def deserialize()(implicit ctx: DeserializationContext): MonthDay = {
+        val month      = read[Month]()
+        val dayOfMonth = readByte()
+        MonthDay.of(month, dayOfMonth.toInt)
+      }
 
-  implicit val yearMonthCodec: BinaryCodec[YearMonth] =
-    BinaryCodec.define((yearMonth: YearMonth) =>
-      for {
-        _ <- writeVarInt(yearMonth.getYear, optimizeForPositive = true)
-        _ <- write(yearMonth.getMonth)
-      } yield ()
-    )(for {
-      year  <- readVarInt(optimizeForPositive = true)
-      month <- read[Month]()
-    } yield YearMonth.of(year, month))
+      override def serialize(value: MonthDay)(implicit context: SerializationContext): Unit = {
+        write(value.getMonth)
+        writeByte(value.getDayOfMonth.toByte)
+      }
+    }
+
+  implicit val yearMonthCodec: BinaryCodec[YearMonth] = new BinaryCodec[YearMonth] {
+    override def deserialize()(implicit ctx: DeserializationContext): YearMonth = {
+      val year  = readVarInt(optimizeForPositive = true)
+      val month = read[Month]()
+      YearMonth.of(year, month)
+    }
+
+    override def serialize(value: YearMonth)(implicit context: SerializationContext): Unit = {
+      writeVarInt(value.getYear, optimizeForPositive = true)
+      write(value.getMonth)
+    }
+  }
 
   implicit val periodCodec: BinaryCodec[Period] =
-    BinaryCodec.define((period: Period) =>
-      for {
-        _ <- writeVarInt(period.getYears, optimizeForPositive = true)
-        _ <- writeVarInt(period.getMonths, optimizeForPositive = true)
-        _ <- writeVarInt(period.getDays, optimizeForPositive = true)
-      } yield ()
-    )(for {
-      years  <- readVarInt(optimizeForPositive = true)
-      months <- readVarInt(optimizeForPositive = true)
-      days   <- readVarInt(optimizeForPositive = true)
-    } yield Period.of(years, months, days))
+    new BinaryCodec[Period] {
+      override def deserialize()(implicit ctx: DeserializationContext): Period = {
+        val years  = readVarInt(optimizeForPositive = true)
+        val months = readVarInt(optimizeForPositive = true)
+        val days   = readVarInt(optimizeForPositive = true)
+        Period.of(years, months, days)
+      }
+
+      override def serialize(value: Period)(implicit context: SerializationContext): Unit = {
+        writeVarInt(value.getYears, optimizeForPositive = true)
+        writeVarInt(value.getMonths, optimizeForPositive = true)
+        writeVarInt(value.getDays, optimizeForPositive = true)
+      }
+    }
 
   implicit val zoneIdCodec: BinaryCodec[ZoneId] =
-    BinaryCodec.define[ZoneId] {
-      case offset: ZoneOffset =>
-        for {
-          _ <- writeByte(0)
-          _ <- writeVarInt(offset.getTotalSeconds, optimizeForPositive = false)
-        } yield ()
-      case region             =>
-        for {
-          _ <- writeByte(1)
-          _ <- write(region.getId)
-        } yield ()
-    }(
-      for {
-        typ    <- readByte()
-        result <-
-          typ match {
-            case 0 =>
-              readVarInt(optimizeForPositive = false).map(totalSeconds => ZoneOffset.ofTotalSeconds(totalSeconds))
-            case 1 => read[String]().map(id => ZoneId.of(id))
-            case 2 => failDeserializerWith(DesertFailure.InvalidConstructorId(typ.toInt, "ZoneId"))
-          }
-      } yield result
-    )
+    new BinaryCodec[ZoneId] {
+      override def deserialize()(implicit ctx: DeserializationContext): ZoneId = {
+        val typ = readByte()
+        typ match {
+          case 0 => ZoneOffset.ofTotalSeconds(readVarInt(optimizeForPositive = false))
+          case 1 => ZoneId.of(read[String]())
+          case _ => throw DesertException(DesertFailure.InvalidConstructorId(typ.toInt, "ZoneId"))
+        }
+      }
+
+      override def serialize(value: ZoneId)(implicit context: SerializationContext): Unit =
+        value match {
+          case offset: ZoneOffset =>
+            writeByte(0)
+            writeVarInt(offset.getTotalSeconds, optimizeForPositive = false)
+          case region             =>
+            writeByte(1)
+            write(region.getId)
+        }
+    }
 
   implicit val zoneOffsetCodec: BinaryCodec[ZoneOffset] =
     BinaryCodec.from(
@@ -219,138 +263,147 @@ trait Codecs extends internal.TupleCodecs {
     )
 
   implicit val durationCodec: BinaryCodec[Duration] =
-    BinaryCodec.define((duration: Duration) =>
-      for {
-        _ <- writeLong(duration.getSeconds)
-        _ <- writeInt(duration.getNano)
-      } yield ()
-    )(for {
-      seconds <- readLong()
-      nanos   <- readInt()
-    } yield Duration.ofSeconds(seconds, nanos.toLong))
+    new BinaryCodec[Duration] {
+      override def deserialize()(implicit ctx: DeserializationContext): Duration = {
+        val seconds = readLong()
+        val nanos   = readInt()
+        Duration.ofSeconds(seconds, nanos.toLong)
+      }
 
-  implicit val instantCodec: BinaryCodec[Instant] =
-    BinaryCodec.define((instant: Instant) =>
-      for {
-        _ <- writeLong(instant.getEpochSecond)
-        _ <- writeInt(instant.getNano)
-      } yield ()
-    )(for {
-      seconds <- readLong()
-      nanos   <- readInt()
-    } yield Instant.ofEpochSecond(seconds, nanos.toLong))
+      override def serialize(value: Duration)(implicit context: SerializationContext): Unit = {
+        writeLong(value.getSeconds)
+        writeInt(value.getNano)
+      }
+    }
+
+  implicit val instantCodec: BinaryCodec[Instant] = new BinaryCodec[Instant] {
+    override def deserialize()(implicit ctx: DeserializationContext): Instant = {
+      val seconds = readLong()
+      val nanos   = readInt()
+      Instant.ofEpochSecond(seconds, nanos.toLong)
+    }
+
+    override def serialize(value: Instant)(implicit context: SerializationContext): Unit = {
+      writeLong(value.getEpochSecond)
+      writeInt(value.getNano)
+    }
+  }
 
   implicit val localDateCodec: BinaryCodec[LocalDate] =
-    BinaryCodec.define((localDate: LocalDate) =>
-      for {
-        _ <- writeVarInt(localDate.getYear, optimizeForPositive = true)
-        _ <- write(localDate.getMonth)
-        _ <- writeByte(localDate.getDayOfMonth.toByte)
-      } yield ()
-    )(for {
-      year       <- readVarInt(optimizeForPositive = true)
-      month      <- read[Month]()
-      dayOfMonth <- readByte()
-    } yield LocalDate.of(year, month, dayOfMonth.toInt))
+    new BinaryCodec[LocalDate] {
+      override def deserialize()(implicit ctx: DeserializationContext): LocalDate = {
+        val year  = readVarInt(optimizeForPositive = true)
+        val month = read[Month]()
+        val day   = readByte()
+        LocalDate.of(year, month, day.toInt)
+      }
+
+      override def serialize(value: LocalDate)(implicit context: SerializationContext): Unit = {
+        writeVarInt(value.getYear, optimizeForPositive = true)
+        write(value.getMonth)
+        writeByte(value.getDayOfMonth.toByte)
+      }
+    }
 
   implicit val localTimeCodec: BinaryCodec[LocalTime] =
-    BinaryCodec.define((localTime: LocalTime) =>
-      for {
-        _ <- writeByte(localTime.getHour.toByte)
-        _ <- writeByte(localTime.getMinute.toByte)
-        _ <- writeByte(localTime.getSecond.toByte)
-        _ <- writeVarInt(localTime.getNano, optimizeForPositive = true)
-      } yield ()
-    )(for {
-      hour   <- readByte()
-      minute <- readByte()
-      second <- readByte()
-      nano   <- readVarInt(optimizeForPositive = true)
-    } yield LocalTime.of(hour, minute, second, nano))
+    new BinaryCodec[LocalTime] {
+      override def deserialize()(implicit ctx: DeserializationContext): LocalTime = {
+        val hour   = readByte()
+        val minute = readByte()
+        val second = readByte()
+        val nano   = readVarInt(optimizeForPositive = true)
+        LocalTime.of(hour, minute, second, nano)
+      }
+
+      override def serialize(value: LocalTime)(implicit context: SerializationContext): Unit = {
+        writeByte(value.getHour.toByte)
+        writeByte(value.getMinute.toByte)
+        writeByte(value.getSecond.toByte)
+        writeVarInt(value.getNano, optimizeForPositive = true)
+      }
+    }
 
   implicit val localDateTimeCodec: BinaryCodec[LocalDateTime] =
-    BinaryCodec.define((localDateTime: LocalDateTime) =>
-      for {
-        _ <- write(localDateTime.toLocalDate)
-        _ <- write(localDateTime.toLocalTime)
-      } yield ()
-    )(for {
-      date <- read[LocalDate]()
-      time <- read[LocalTime]()
-    } yield LocalDateTime.of(date, time))
+    new BinaryCodec[LocalDateTime] {
+      override def deserialize()(implicit ctx: DeserializationContext): LocalDateTime = {
+        val date = read[LocalDate]()
+        val time = read[LocalTime]()
+        LocalDateTime.of(date, time)
+      }
+
+      override def serialize(value: LocalDateTime)(implicit context: SerializationContext): Unit = {
+        write(value.toLocalDate)
+        write(value.toLocalTime)
+      }
+    }
 
   implicit val offsetTimeCodec: BinaryCodec[OffsetTime] =
-    BinaryCodec.define((offsetTime: OffsetTime) =>
-      for {
-        _ <- write(offsetTime.toLocalTime)
-        _ <- write(offsetTime.getOffset)
-      } yield ()
-    )(for {
-      time   <- read[LocalTime]()
-      offset <- read[ZoneOffset]()
-    } yield OffsetTime.of(time, offset))
+    new BinaryCodec[OffsetTime] {
+      override def deserialize()(implicit ctx: DeserializationContext): OffsetTime = {
+        val time   = read[LocalTime]()
+        val offset = read[ZoneOffset]()
+        OffsetTime.of(time, offset)
+      }
+
+      override def serialize(value: OffsetTime)(implicit context: SerializationContext): Unit = {
+        write(value.toLocalTime)
+        write(value.getOffset)
+      }
+    }
 
   implicit val offsetDateTimeCodec: BinaryCodec[OffsetDateTime] =
-    BinaryCodec.define((offsetDateTime: OffsetDateTime) =>
-      for {
-        _ <- write(offsetDateTime.toLocalDateTime)
-        _ <- write(offsetDateTime.getOffset)
-      } yield ()
-    )(for {
-      dateTime <- read[LocalDateTime]()
-      offset   <- read[ZoneOffset]()
-    } yield OffsetDateTime.of(dateTime, offset))
+    new BinaryCodec[OffsetDateTime] {
+      override def deserialize()(implicit ctx: DeserializationContext): OffsetDateTime = {
+        val dateTime = read[LocalDateTime]()
+        val offset   = read[ZoneOffset]()
+        OffsetDateTime.of(dateTime, offset)
+      }
+
+      override def serialize(value: OffsetDateTime)(implicit context: SerializationContext): Unit = {
+        write(value.toLocalDateTime)
+        write(value.getOffset)
+      }
+    }
 
   implicit val zonedDateTimeCodec: BinaryCodec[ZonedDateTime] =
-    BinaryCodec.define((offsetDateTime: ZonedDateTime) =>
-      for {
-        _ <- write(offsetDateTime.toLocalDateTime)
-        _ <- write(offsetDateTime.getOffset)
-        _ <- write(offsetDateTime.getZone)
-      } yield ()
-    )(for {
-      dateTime <- read[LocalDateTime]()
-      offset   <- read[ZoneOffset]()
-      zone     <- read[ZoneId]()
-    } yield ZonedDateTime.ofStrict(dateTime, offset, zone))
-
-  private[desert] final case class OptionBinaryCodec[T]()(implicit val innerCodec: BinaryCodec[T])
-      extends BinaryCodec[Option[T]] {
-    override def deserialize(): Deser[Option[T]] =
-      for {
-        isDefined <- read[Boolean]()
-        result    <- if (isDefined) read[T]().map(Some.apply) else finishDeserializerWith(None)
-      } yield result
-
-    override def serialize(value: Option[T]): io.github.vigoo.desert.Ser[Unit] =
-      value match {
-        case Some(value) => write(true) *> write(value)
-        case None        => write(false)
+    new BinaryCodec[ZonedDateTime] {
+      override def deserialize()(implicit ctx: DeserializationContext): ZonedDateTime = {
+        val dateTime = read[LocalDateTime]()
+        val offset   = read[ZoneOffset]()
+        val zone     = read[ZoneId]()
+        ZonedDateTime.ofStrict(dateTime, offset, zone)
       }
-  }
+
+      override def serialize(value: ZonedDateTime)(implicit context: SerializationContext): Unit = {
+        write(value.toLocalDateTime)
+        write(value.getOffset)
+        write(value.getZone)
+      }
+    }
 
   implicit def optionCodec[T: BinaryCodec]: BinaryCodec[Option[T]] = OptionBinaryCodec[T]()
 
   // Throwable
 
   implicit val stackTraceElementCodec: BinaryCodec[StackTraceElement] =
-    BinaryCodec.define[StackTraceElement](stackTraceElement =>
-      for {
-        _ <- writeByte(0) // version
-        _ <- write(Option(stackTraceElement.getClassName))
-        _ <- write(Option(stackTraceElement.getMethodName))
-        _ <- write(Option(stackTraceElement.getFileName))
-        _ <- writeVarInt(stackTraceElement.getLineNumber, optimizeForPositive = true)
-      } yield ()
-    )(
-      for {
-        _          <- readByte() // version
-        className  <- read[Option[String]]()
-        methodName <- read[Option[String]]()
-        fileName   <- read[Option[String]]()
-        lineNumber <- readVarInt(optimizeForPositive = true)
-      } yield new StackTraceElement(className.orNull, methodName.orNull, fileName.orNull, lineNumber)
-    )
+    new BinaryCodec[StackTraceElement] {
+      override def deserialize()(implicit ctx: DeserializationContext): StackTraceElement = {
+        val _          = readByte()
+        val className  = read[Option[String]]()
+        val methodName = read[Option[String]]()
+        val fileName   = read[Option[String]]()
+        val lineNumber = readVarInt(optimizeForPositive = true)
+        new StackTraceElement(className.orNull, methodName.orNull, fileName.orNull, lineNumber)
+      }
+
+      override def serialize(value: StackTraceElement)(implicit context: SerializationContext): Unit = {
+        writeByte(0)
+        write(Option(value.getClassName))
+        write(Option(value.getMethodName))
+        write(Option(value.getFileName))
+        writeVarInt(value.getLineNumber, optimizeForPositive = true)
+      }
+    }
 
   implicit def persistedThrowableCodec: BinaryCodec[PersistedThrowable] =
     new AdtCodec[PersistedThrowable, PersistedThrowable](
@@ -385,7 +438,7 @@ trait Codecs extends internal.TupleCodecs {
           (cause: Option[PersistedThrowable], pt: PersistedThrowable) => pt.copy(cause = cause)
         )
       ),
-      initialBuilderState = PersistedThrowable("", "", Array.empty, None),
+      initialBuilderState = () => PersistedThrowable("", "", Array.empty, None),
       materialize = Right(_)
     )
 
@@ -398,64 +451,57 @@ trait Codecs extends internal.TupleCodecs {
 
   def iterableCodec[A: BinaryCodec, T <: Iterable[A]](implicit factory: Factory[A, T]): BinaryCodec[T] =
     new BinaryCodec[T] {
-      override def deserialize(): Deser[T] =
-        for {
-          knownSize <- readVarInt(optimizeForPositive = false)
-          result    <- if (knownSize == -1) {
-                         deserializeWithUnknownSize()
-                       } else {
-                         deserializeWithKnownSize(knownSize)
-                       }
-        } yield result
-
-      private def deserializeWithUnknownSize(): Deser[T] = {
-        val builder = factory.newBuilder
-        readAll(builder).map(_.result())
+      override def deserialize()(implicit ctx: DeserializationContext): T = {
+        val knownSize = readVarInt(optimizeForPositive = false)
+        if (knownSize == -1)
+          deserializeWithUnknownSize()
+        else
+          deserializeWithKnownSize(knownSize)
       }
 
-      private def readAll(builder: mutable.Builder[A, T]): Deser[mutable.Builder[A, T]] =
-        readNext().flatMap {
-          case None       => finishDeserializerWith(builder)
-          case Some(elem) => readAll(builder += elem)
+      private def deserializeWithUnknownSize()(implicit ctx: DeserializationContext): T = {
+        val builder = factory.newBuilder
+        readAll(builder)
+        builder.result()
+      }
+
+      @tailrec
+      private def readAll(builder: mutable.Builder[A, T])(implicit ctx: DeserializationContext): Unit =
+        read[Option[A]]() match {
+          case Some(value) =>
+            builder += value
+            readAll(builder)
+          case None        =>
         }
 
-      private def readNext(): Deser[Option[A]] =
-        read[Option[A]]()
-
-      private def deserializeWithKnownSize(size: Int): Deser[T] = {
+      private def deserializeWithKnownSize(size: Int)(implicit ctx: DeserializationContext): T = {
         val builder = factory.newBuilder
         builder.sizeHint(size)
-
-        (0 until size)
-          .foldLeft(finishDeserializerWith(builder)) { case (b, _) =>
-            b.flatMap(b => read[A]().map(b += _))
-          }
-          .map(_.result())
+        for (_ <- 0 until size)
+          builder += read[A]()
+        builder.result()
       }
 
-      override def serialize(value: T): io.github.vigoo.desert.Ser[Unit] =
-        if (value.knownSize == -1) {
+      override def serialize(value: T)(implicit context: SerializationContext): Unit =
+        if (value.knownSize == -1)
           serializeWithUnknownSize(value)
-        } else {
+        else
           serializeWithKnownSize(value, value.knownSize)
+
+      private def serializeWithUnknownSize(value: T)(implicit context: SerializationContext): Unit = {
+        writeVarInt(-1, optimizeForPositive = false)
+        for (elem <- value) {
+          write(true)
+          write(elem)
         }
+        write(false)
+      }
 
-      private def serializeWithUnknownSize(value: T): io.github.vigoo.desert.Ser[Unit] =
-        for {
-          _ <- writeVarInt(-1, optimizeForPositive = false)
-          _ <- value.foldRight(finishSerializer()) { case (elem, rest) =>
-                 write(true) *> write(elem) *> rest
-               }
-          _ <- write(false)
-        } yield ()
-
-      private def serializeWithKnownSize(value: T, size: Int): io.github.vigoo.desert.Ser[Unit] =
-        for {
-          _ <- writeVarInt(size, optimizeForPositive = false)
-          _ <- value.foldRight(finishSerializer()) { case (elem, rest) =>
-                 write(elem) *> rest
-               }
-        } yield ()
+      private def serializeWithKnownSize(value: T, size: Int)(implicit context: SerializationContext): Unit = {
+        writeVarInt(size, optimizeForPositive = false)
+        for (elem <- value)
+          write(elem)
+      }
     }
 
   implicit def wrappedArrayCodec[A: BinaryCodec: ClassTag]: BinaryCodec[ArraySeq[A]] = iterableCodec[A, ArraySeq[A]]
@@ -479,30 +525,34 @@ trait Codecs extends internal.TupleCodecs {
     iterableCodec[(K, V), SortedMap[K, V]]
 
   implicit def eitherCodec[L: BinaryCodec, R: BinaryCodec]: BinaryCodec[Either[L, R]] = new BinaryCodec[Either[L, R]] {
-    override def deserialize(): Deser[Either[L, R]] =
-      for {
-        isRight <- read[Boolean]()
-        result  <- if (isRight) read[R]().map(Right.apply) else read[L]().map(Left.apply)
-      } yield result
 
-    override def serialize(value: Either[L, R]): io.github.vigoo.desert.Ser[Unit] =
+    override def deserialize()(implicit ctx: DeserializationContext): Either[L, R] = {
+      val isRight = read[Boolean]()
+      if (isRight) Right(read[R]()) else Left(read[L]())
+    }
+
+    override def serialize(value: Either[L, R])(implicit context: SerializationContext): Unit =
       value match {
-        case Left(value)  => write(false) *> write(value)
-        case Right(value) => write(true) *> write(value)
+        case Left(value)  =>
+          write(false)
+          write(value)
+        case Right(value) =>
+          write(true)
+          write(value)
       }
   }
 
   implicit def tryCodec[A: BinaryCodec]: BinaryCodec[Try[A]] = new BinaryCodec[Try[A]] {
-    override def deserialize(): Deser[Try[A]] =
-      for {
-        isSuccess <- read[Boolean]()
-        result    <- if (isSuccess) read[A]().map(Success.apply) else read[Throwable]().map(Failure.apply)
-      } yield result
 
-    override def serialize(value: Try[A]): io.github.vigoo.desert.Ser[Unit] =
+    override def deserialize()(implicit ctx: DeserializationContext): Try[A] = {
+      val isSuccess = read[Boolean]()
+      if (isSuccess) Success(read[A]()) else Failure(read[Throwable]())
+    }
+
+    override def serialize(value: Try[A])(implicit context: SerializationContext): Unit =
       value match {
-        case Failure(reason) => write(false) *> write(reason)
-        case Success(value)  => write(true) *> write(value)
+        case Failure(reason) => write(false); write(reason)
+        case Success(value)  => write(true); write(value)
       }
   }
 
@@ -512,35 +562,35 @@ trait Codecs extends internal.TupleCodecs {
     val inner = iterableCodec[A, Chunk[A]](BinaryCodec[A], Chunk.iterableFactory)
     BinaryCodec.from(
       inner.contramap(_.toChunk),
-      () =>
-        inner.deserialize().flatMap { chunk =>
+      new BinaryDeserializer[NonEmptyChunk[A]] {
+        override def deserialize()(implicit ctx: DeserializationContext): NonEmptyChunk[A] = {
+          val chunk = inner.deserialize()
           NonEmptyChunk.fromChunk(chunk) match {
-            case Some(nonEmptyChunk) => finishDeserializerWith(nonEmptyChunk)
+            case Some(nonEmptyChunk) => nonEmptyChunk
             case None                =>
               failDeserializerWith(DesertFailure.DeserializationFailure("Non empty chunk is serialized as empty", None))
           }
         }
+      }
     )
   }
 
   implicit def validationCodec[E: BinaryCodec, A: BinaryCodec]: BinaryCodec[Validation[E, A]] =
     new BinaryCodec[Validation[E, A]] {
-      override def deserialize(): Deser[Validation[E, A]] =
-        for {
-          isValid <- read[Boolean]()
-          result  <-
-            if (isValid)
-              read[A]().map(Validation.succeed[A])
-            else
-              read[NonEmptyChunk[E]]().map { errors =>
-                Validation.validateAll(errors.map(Validation.fail)).map(x => x.asInstanceOf[A])
-              }
-        } yield result
+      override def deserialize()(implicit ctx: DeserializationContext): Validation[E, A] = {
+        val isValid = read[Boolean]()
+        if (isValid)
+          Validation.succeed(read[A]())
+        else {
+          val errors = read[NonEmptyChunk[E]]()
+          Validation.validateAll(errors.map(Validation.fail(_))).map(_.asInstanceOf[A])
+        }
+      }
 
-      override def serialize(value: Validation[E, A]): io.github.vigoo.desert.Ser[Unit] =
+      override def serialize(value: Validation[E, A])(implicit context: SerializationContext): Unit =
         value match {
-          case Validation.Failure(_, value) => write(false) *> write(value)
-          case Validation.Success(_, value) => write(true) *> write(value)
+          case Validation.Failure(_, value) => write(false); write(value)
+          case Validation.Success(_, value) => write(true); write(value)
         }
     }
 
@@ -548,12 +598,14 @@ trait Codecs extends internal.TupleCodecs {
     val inner = listCodec[A]
     BinaryCodec.from(
       inner.contramap(_.toList),
-      () =>
-        inner.deserialize().flatMap {
-          case x :: xs => finishDeserializerWith(NonEmptyList.fromIterable(x, xs))
-          case Nil     =>
-            failDeserializerWith(DesertFailure.DeserializationFailure("Non empty list is serialized as empty", None))
-        }
+      new BinaryDeserializer[NonEmptyList[A]] {
+        override def deserialize()(implicit ctx: DeserializationContext): NonEmptyList[A] =
+          inner.deserialize() match {
+            case x :: xs => NonEmptyList.fromIterable(x, xs)
+            case Nil     =>
+              failDeserializerWith(DesertFailure.DeserializationFailure("Non empty list is serialized as empty", None))
+          }
+      }
     )
   }
 

--- a/desert-core/src/main/scala/io/github/vigoo/desert/Codecs.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/Codecs.scala
@@ -6,7 +6,7 @@ import io.github.vigoo.desert.custom._
 import io.github.vigoo.desert.internal.SerializerState.{StringAlreadyStored, StringId, StringIsNew}
 import _root_.zio.{Chunk, NonEmptyChunk}
 import _root_.zio.prelude.{Associative, NonEmptyList, Validation, ZSet}
-import io.github.vigoo.desert.internal.{AdtCodec, DeserializationContext, OptionBinaryCodec, SerializationContext}
+import io.github.vigoo.desert.internal.{AdtCodec, OptionBinaryCodec}
 
 import java.time._
 import scala.annotation.tailrec

--- a/desert-core/src/main/scala/io/github/vigoo/desert/DesertException.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/DesertException.scala
@@ -6,6 +6,6 @@ package io.github.vigoo.desert
   * @param failure
   *   The failure to represent in the exception
   */
-class DesertException(failure: DesertFailure) extends Exception(failure.message) {
+final case class DesertException(failure: DesertFailure) extends Exception(failure.message) {
   failure.cause.foreach(initCause)
 }

--- a/desert-core/src/main/scala/io/github/vigoo/desert/RegisteredType.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/RegisteredType.scala
@@ -1,8 +1,8 @@
 package io.github.vigoo.desert
 
 import io.github.vigoo.desert.TypeRegistry.RegisteredTypeId
-import io.github.vigoo.desert.custom.failSerializerWith
-import io.github.vigoo.desert.internal.{SerializationContext, SerializationEnv, SerializerState}
+import io.github.vigoo.desert.custom.{SerializationContext, failSerializerWith}
+import io.github.vigoo.desert.internal.{SerializationEnv, SerializerState}
 
 import scala.util.{Failure, Success, Try}
 

--- a/desert-core/src/main/scala/io/github/vigoo/desert/RegisteredType.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/RegisteredType.scala
@@ -2,11 +2,12 @@ package io.github.vigoo.desert
 
 import io.github.vigoo.desert.TypeRegistry.RegisteredTypeId
 import io.github.vigoo.desert.custom.failSerializerWith
+import io.github.vigoo.desert.internal.{SerializationContext, SerializationEnv, SerializerState}
 
 import scala.util.{Failure, Success, Try}
 
 final case class RegisteredType[T](id: RegisteredTypeId, codec: BinaryCodec[T], cls: Class[_]) {
-  def serialize(value: Any): Ser[Unit] =
+  def serialize(value: Any)(implicit ctx: SerializationContext): Unit =
     Try(value.asInstanceOf[T]) match {
       case Success(upcasted)  => codec.serialize(upcasted)
       case Failure(exception) =>

--- a/desert-core/src/main/scala/io/github/vigoo/desert/custom/BinaryDeserializerOps.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/custom/BinaryDeserializerOps.scala
@@ -1,7 +1,6 @@
 package io.github.vigoo.desert.custom
 
 import io.github.vigoo.desert.TypeRegistry.RegisteredTypeId
-import io.github.vigoo.desert.internal.DeserializationContext
 import io.github.vigoo.desert.internal.SerializerState.{RefId, StringId}
 import io.github.vigoo.desert.{BinaryCodec, BinaryDeserializer, DesertException, DesertFailure}
 

--- a/desert-core/src/main/scala/io/github/vigoo/desert/custom/BinaryDeserializerOps.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/custom/BinaryDeserializerOps.scala
@@ -1,86 +1,72 @@
 package io.github.vigoo.desert.custom
 
 import io.github.vigoo.desert.TypeRegistry.RegisteredTypeId
-import io.github.vigoo.desert.internal.SerializerState
+import io.github.vigoo.desert.internal.DeserializationContext
 import io.github.vigoo.desert.internal.SerializerState.{RefId, StringId}
-import io.github.vigoo.desert._
-import zio.prelude.fx.ZPure
-
-import scala.util.Try
+import io.github.vigoo.desert.{BinaryCodec, BinaryDeserializer, DesertException, DesertFailure}
 
 trait BinaryDeserializerOps {
-  final def getInput: Deser[BinaryInput]                              = ZPure.serviceWith(_.input)
-  final def getInputTypeRegistry: Deser[TypeRegistry]                 = ZPure.serviceWith(_.typeRegistry)
-  final def getDeserializerState: Deser[SerializerState]              = ZPure.get
-  final def setDeserializerState(state: SerializerState): Deser[Unit] = ZPure.set(state)
 
-  final def readByte(): Deser[Byte]                              = getInput.flatMap(input => Deser.fromEither(input.readByte()))
-  final def readShort(): Deser[Short]                            = getInput.flatMap(input => Deser.fromEither(input.readShort()))
-  final def readInt(): Deser[Int]                                = getInput.flatMap(input => Deser.fromEither(input.readInt()))
-  final def readVarInt(optimizeForPositive: Boolean): Deser[Int] =
-    getInput.flatMap(input => Deser.fromEither(input.readVarInt(optimizeForPositive)))
-  final def readLong(): Deser[Long]                              = getInput.flatMap(input => Deser.fromEither(input.readLong()))
-  final def readFloat(): Deser[Float]                            = getInput.flatMap(input => Deser.fromEither(input.readFloat()))
-  final def readDouble(): Deser[Double]                          = getInput.flatMap(input => Deser.fromEither(input.readDouble()))
-  final def readBytes(count: Int): Deser[Array[Byte]]            =
-    getInput.flatMap(input => Deser.fromEither(input.readBytes(count)))
-  final def readCompressedByteArray(): Deser[Array[Byte]]        =
-    getInput.flatMap(input => Deser.fromEither(input.readCompressedByteArray()))
-  final def read[T: BinaryDeserializer](): Deser[T]              = implicitly[BinaryDeserializer[T]].deserialize()
+  final def failDeserializerWith[T](failure: DesertFailure): Nothing = throw DesertException(failure)
 
-  final def readUnknown(): Deser[Any] =
-    for {
-      typeRegistry <- getInputTypeRegistry
-      typeId       <- readVarInt(optimizeForPositive = true).map(RegisteredTypeId.apply)
-      result       <- typeRegistry.forId(typeId) match {
-                        case Some(registration) =>
-                          registration.codec.deserialize()
-                        case None               =>
-                          failDeserializerWith(DesertFailure.InvalidTypeId(typeId))
-                      }
-    } yield result
+  final def readByte()(implicit ctx: DeserializationContext): Byte = ctx.env.input.readByte()
 
-  final def finishDeserializerWith[T](value: T): Deser[T]                    = Deser.fromEither(Right(value))
-  final def failDeserializerWith[T](failure: DesertFailure): Deser[T]        = Deser.fromEither(Left(failure))
-  final def deserializerFromTry[T](f: Try[T], failMessage: String): Deser[T] =
-    Deser.fromEither(f.toEither.left.map(failure => DesertFailure.DeserializationFailure(failMessage, Some(failure))))
+  final def readShort()(implicit ctx: DeserializationContext): Short = ctx.env.input.readShort()
 
-  final def getString(value: StringId): Deser[Option[String]] =
-    for {
-      state <- getDeserializerState
-    } yield state.stringsById.get(value)
+  final def readInt()(implicit ctx: DeserializationContext): Int = ctx.env.input.readInt()
 
-  final def storeReadString(value: String): Deser[Unit] =
-    for {
-      state        <- getDeserializerState
-      (newState, _) = state.storeString(value)
-      _            <- setDeserializerState(newState)
-    } yield ()
+  final def readVarInt(optimizeForPositive: Boolean)(implicit ctx: DeserializationContext): Int =
+    ctx.env.input.readVarInt(optimizeForPositive)
 
-  final def getRef(value: RefId): Deser[Option[AnyRef]] =
-    for {
-      state <- getDeserializerState
-    } yield state.refsById.get(value)
+  final def readLong()(implicit ctx: DeserializationContext): Long = ctx.env.input.readLong()
 
-  final def storeReadRef(value: AnyRef): Deser[Unit] =
-    for {
-      state        <- getDeserializerState
-      (newState, _) = state.storeRef(value)
-      _            <- setDeserializerState(newState)
-    } yield ()
+  final def readFloat()(implicit ctx: DeserializationContext): Float = ctx.env.input.readFloat()
 
-  // TODO: need the codec to be lazy?
-  def readRefOrValue[T <: AnyRef](storeReadReference: Boolean = true)(implicit codec: BinaryCodec[T]): Deser[T] =
-    readVarInt(optimizeForPositive = true).flatMap {
+  final def readDouble()(implicit ctx: DeserializationContext): Double = ctx.env.input.readDouble()
+
+  final def readBytes(count: Int)(implicit ctx: DeserializationContext): Array[Byte] =
+    ctx.env.input.readBytes(count)
+
+  final def readCompressedByteArray()(implicit ctx: DeserializationContext): Array[Byte] =
+    ctx.env.input.readCompressedByteArray()
+
+  final def read[T: BinaryDeserializer]()(implicit ctx: DeserializationContext): T =
+    implicitly[BinaryDeserializer[T]].deserialize()
+
+  final def readUnknown()(implicit ctx: DeserializationContext): Any = {
+    val typeId = RegisteredTypeId(readVarInt(optimizeForPositive = true))
+    ctx.env.typeRegistry.forId(typeId) match {
+      case Some(registration) =>
+        registration.codec.deserialize()
+      case None               =>
+        failDeserializerWith(DesertFailure.InvalidTypeId(typeId))
+    }
+  }
+
+  final def getString(value: StringId)(implicit ctx: DeserializationContext): Option[String] =
+    ctx.state.getStringById(value)
+
+  final def storeReadString(value: String)(implicit ctx: DeserializationContext): Unit =
+    ctx.state.storeString(value)
+
+  final def getRef(value: RefId)(implicit ctx: DeserializationContext): Option[AnyRef] =
+    ctx.state.getRefById(value)
+
+  final def storeReadRef(value: AnyRef)(implicit ctx: DeserializationContext): Unit =
+    ctx.state.storeRef(value)
+
+  def readRefOrValue[T <: AnyRef](
+      storeReadReference: Boolean = true
+  )(implicit codec: BinaryCodec[T], ctx: DeserializationContext): T =
+    readVarInt(optimizeForPositive = true) match {
       case 0  =>
-        for {
-          value <- read[T]()
-          _     <- if (storeReadReference) storeReadRef(value) else finishDeserializerWith(())
-        } yield value
+        val value = read[T]()
+        if (storeReadReference) storeReadRef(value)
+        value
       case id =>
-        getRef(RefId(id)).flatMap {
+        getRef(RefId(id)) match {
           case None        => failDeserializerWith(DesertFailure.InvalidRefId(RefId(id)))
-          case Some(value) => finishDeserializerWith(value.asInstanceOf[T])
+          case Some(value) => value.asInstanceOf[T]
         }
     }
 }

--- a/desert-core/src/main/scala/io/github/vigoo/desert/custom/BinarySerializerOps.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/custom/BinarySerializerOps.scala
@@ -1,6 +1,5 @@
 package io.github.vigoo.desert.custom
 
-import io.github.vigoo.desert.internal.SerializationContext
 import io.github.vigoo.desert.internal.SerializerState.{RefAlreadyStored, RefIsNew, StoreRefResult, StoreStringResult}
 import io.github.vigoo.desert.{BinaryCodec, BinarySerializer, DesertException, DesertFailure}
 

--- a/desert-core/src/main/scala/io/github/vigoo/desert/custom/BinarySerializerOps.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/custom/BinarySerializerOps.scala
@@ -1,72 +1,69 @@
 package io.github.vigoo.desert.custom
 
-import io.github.vigoo.desert.internal.SerializerState
+import io.github.vigoo.desert.internal.SerializationContext
 import io.github.vigoo.desert.internal.SerializerState.{RefAlreadyStored, RefIsNew, StoreRefResult, StoreStringResult}
-import io.github.vigoo.desert._
-import zio.prelude.fx.ZPure
+import io.github.vigoo.desert.{BinaryCodec, BinarySerializer, DesertException, DesertFailure}
 
 import java.util.zip.Deflater
-import scala.util.Try
 
 trait BinarySerializerOps {
-  final def getOutput: Ser[BinaryOutput]                          = ZPure.serviceWith(_.output)
-  final def getOutputTypeRegistry: Ser[TypeRegistry]              = ZPure.serviceWith(_.typeRegistry)
-  final def getSerializerState: Ser[SerializerState]              = ZPure.get
-  final def setSerializerState(state: SerializerState): Ser[Unit] = ZPure.set(state)
 
-  final def writeByte(value: Byte): Ser[Unit]                                                     = getOutput.flatMap(output => Ser.fromEither(output.writeByte(value)))
-  final def writeShort(value: Short): Ser[Unit]                                                   = getOutput.flatMap(output => Ser.fromEither(output.writeShort(value)))
-  final def writeInt(value: Int): Ser[Unit]                                                       = getOutput.flatMap(output => Ser.fromEither(output.writeInt(value)))
-  final def writeVarInt(value: Int, optimizeForPositive: Boolean): Ser[Unit]                      =
-    getOutput.flatMap(output => Ser.fromEither(output.writeVarInt(value, optimizeForPositive)))
-  final def writeLong(value: Long): Ser[Unit]                                                     = getOutput.flatMap(output => Ser.fromEither(output.writeLong(value)))
-  final def writeFloat(value: Float): Ser[Unit]                                                   = getOutput.flatMap(output => Ser.fromEither(output.writeFloat(value)))
-  final def writeDouble(value: Double): Ser[Unit]                                                 =
-    getOutput.flatMap(output => Ser.fromEither(output.writeDouble(value)))
-  final def writeBytes(value: Array[Byte]): Ser[Unit]                                             =
-    getOutput.flatMap(output => Ser.fromEither(output.writeBytes(value)))
-  final def writeCompressedBytes(value: Array[Byte], level: Int = Deflater.BEST_SPEED): Ser[Unit] =
-    getOutput.flatMap(output => Ser.fromEither(output.writeCompressedByteArray(value, level)))
+  final def failSerializerWith(failure: DesertFailure): Nothing =
+    throw DesertException(failure)
 
-  final def writeUnknown(value: Any): Ser[Unit] =
-    getOutputTypeRegistry.flatMap { typeRegistry =>
-      typeRegistry.get(value) match {
-        case Some(registration) =>
-          for {
-            _ <- writeVarInt(registration.id.value, optimizeForPositive = true)
-            _ <- registration.serialize(value)
-          } yield ()
-        case None               =>
-          failSerializerWith(DesertFailure.TypeNotRegistered(value.getClass))
-      }
+  final def writeByte(value: Byte)(implicit ctx: SerializationContext): Unit =
+    ctx.env.output.writeByte(value)
+
+  final def writeShort(value: Short)(implicit ctx: SerializationContext): Unit =
+    ctx.env.output.writeShort(value)
+
+  final def writeInt(value: Int)(implicit ctx: SerializationContext): Unit =
+    ctx.env.output.writeInt(value)
+
+  final def writeVarInt(value: Int, optimizeForPositive: Boolean)(implicit ctx: SerializationContext): Unit =
+    ctx.env.output.writeVarInt(value, optimizeForPositive)
+
+  final def writeLong(value: Long)(implicit ctx: SerializationContext): Unit =
+    ctx.env.output.writeLong(value)
+
+  final def writeFloat(value: Float)(implicit ctx: SerializationContext): Unit =
+    ctx.env.output.writeFloat(value)
+
+  final def writeDouble(value: Double)(implicit ctx: SerializationContext): Unit =
+    ctx.env.output.writeDouble(value)
+
+  final def writeBytes(value: Array[Byte])(implicit ctx: SerializationContext): Unit =
+    ctx.env.output.writeBytes(value)
+
+  final def writeCompressedBytes(value: Array[Byte], level: Int = Deflater.BEST_SPEED)(implicit
+      ctx: SerializationContext
+  ): Unit =
+    ctx.env.output.writeCompressedByteArray(value, level)
+
+  final def writeUnknown(value: Any)(implicit ctx: SerializationContext): Unit =
+    ctx.env.typeRegistry.get(value) match {
+      case Some(registration) =>
+        writeVarInt(registration.id.value, optimizeForPositive = true)
+        registration.serialize(value)
+      case None               =>
+        failSerializerWith(DesertFailure.TypeNotRegistered(value.getClass))
     }
 
-  final def write[U: BinarySerializer](value: U): Ser[Unit] = implicitly[BinarySerializer[U]].serialize(value)
+  final def write[U: BinarySerializer](value: U)(implicit ctx: SerializationContext): Unit =
+    implicitly[BinarySerializer[U]].serialize(value)
 
-  final def finishSerializer(): Ser[Unit]                                  = finishSerializerWith(())
-  final def finishSerializerWith[T](value: T): Ser[T]                      = Ser.fromEither(Right(value))
-  final def failSerializerWith(failure: DesertFailure): Ser[Unit]          = Ser.fromEither(Left(failure))
-  final def serializerFromTry[T](f: Try[T], failMessage: String): Deser[T] =
-    Deser.fromEither(f.toEither.left.map(failure => DesertFailure.SerializationFailure(failMessage, Some(failure))))
+  final def storeString(value: String)(implicit ctx: SerializationContext): StoreStringResult =
+    ctx.state.storeString(value)
 
-  final def storeString(value: String): Ser[StoreStringResult] =
-    for {
-      state             <- getSerializerState
-      (newState, result) = state.storeString(value)
-      _                 <- setSerializerState(newState)
-    } yield result
+  final def storeRef(value: AnyRef)(implicit ctx: SerializationContext): StoreRefResult =
+    ctx.state.storeRef(value)
 
-  final def storeRef(value: AnyRef): Ser[StoreRefResult] =
-    for {
-      state             <- getSerializerState
-      (newState, result) = state.storeRef(value)
-      _                 <- setSerializerState(newState)
-    } yield result
-
-  // TODO: needs the codec to be lazy?
-  final def storeRefOrObject[T <: AnyRef](value: T)(implicit codec: BinaryCodec[T]): Ser[Unit] =
-    storeRef(value).flatMap {
-      case RefAlreadyStored(id) => writeVarInt(id.value, optimizeForPositive = true)
-      case RefIsNew(_)          => writeVarInt(0, optimizeForPositive = true) *> write(value)
+  final def storeRefOrObject[T <: AnyRef](value: T)(implicit codec: BinaryCodec[T], ctx: SerializationContext): Unit =
+    storeRef(value) match {
+      case RefAlreadyStored(id) =>
+        writeVarInt(id.value, optimizeForPositive = true)
+      case RefIsNew(_)          =>
+        writeVarInt(0, optimizeForPositive = true)
+        write(value)
     }
 }

--- a/desert-core/src/main/scala/io/github/vigoo/desert/custom/DeserializationContext.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/custom/DeserializationContext.scala
@@ -1,0 +1,5 @@
+package io.github.vigoo.desert.custom
+
+import io.github.vigoo.desert.internal.{DeserializationEnv, SerializerState}
+
+final case class DeserializationContext(env: DeserializationEnv, state: SerializerState)

--- a/desert-core/src/main/scala/io/github/vigoo/desert/custom/SerializationContext.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/custom/SerializationContext.scala
@@ -1,0 +1,5 @@
+package io.github.vigoo.desert.custom
+
+import io.github.vigoo.desert.internal.{SerializationEnv, SerializerState}
+
+final case class SerializationContext(env: SerializationEnv, state: SerializerState)

--- a/desert-core/src/main/scala/io/github/vigoo/desert/custom/pure/PureBinaryDeserializerOps.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/custom/pure/PureBinaryDeserializerOps.scala
@@ -1,0 +1,128 @@
+package io.github.vigoo.desert.custom.pure
+
+import io.github.vigoo.desert.TypeRegistry.RegisteredTypeId
+import io.github.vigoo.desert.internal.{
+  DeserializationContext,
+  DeserializationEnv,
+  PureSerializerState,
+  SerializerState
+}
+import io.github.vigoo.desert.internal.SerializerState.{RefId, StringId}
+import io.github.vigoo.desert.{
+  BinaryCodec,
+  BinaryDeserializer,
+  BinaryInput,
+  DesertException,
+  DesertFailure,
+  TypeRegistry
+}
+import zio.prelude.fx.ZPure
+
+import scala.util.Try
+
+trait PureBinaryDeserializerOps {
+  final def getInput: Deser[BinaryInput]                                  = ZPure.serviceWith(_.input)
+  final def getInputTypeRegistry: Deser[TypeRegistry]                     = ZPure.serviceWith(_.typeRegistry)
+  final def getDeserializationEnv: Deser[DeserializationEnv]              = ZPure.service
+  final def getDeserializerState: Deser[PureSerializerState]              = ZPure.get
+  final def setDeserializerState(state: PureSerializerState): Deser[Unit] = ZPure.set(state)
+
+  final def readByte(): Deser[Byte]                              = getInput.flatMap(input => Deser.attempt(input.readByte()))
+  final def readShort(): Deser[Short]                            = getInput.flatMap(input => Deser.attempt(input.readShort()))
+  final def readInt(): Deser[Int]                                = getInput.flatMap(input => Deser.attempt(input.readInt()))
+  final def readVarInt(optimizeForPositive: Boolean): Deser[Int] =
+    getInput.flatMap(input => Deser.attempt(input.readVarInt(optimizeForPositive)))
+  final def readLong(): Deser[Long]                              = getInput.flatMap(input => Deser.attempt(input.readLong()))
+  final def readFloat(): Deser[Float]                            = getInput.flatMap(input => Deser.attempt(input.readFloat()))
+  final def readDouble(): Deser[Double]                          = getInput.flatMap(input => Deser.attempt(input.readDouble()))
+  final def readBytes(count: Int): Deser[Array[Byte]]            =
+    getInput.flatMap(input => Deser.attempt(input.readBytes(count)))
+  final def readCompressedByteArray(): Deser[Array[Byte]]        =
+    getInput.flatMap(input => Deser.attempt(input.readCompressedByteArray()))
+
+  final def read[T: BinaryDeserializer](): Deser[T] =
+    for {
+      state             <- getDeserializerState
+      env               <- getDeserializationEnv
+      pair              <- runUnsafeDeserializer(state, env, implicitly[BinaryDeserializer[T]])
+      (result, newState) = pair
+      _                 <- setDeserializerState(newState)
+    } yield result
+
+  private def runUnsafeDeserializer[T](
+      state: PureSerializerState,
+      env: DeserializationEnv,
+      deserializer: BinaryDeserializer[T]
+  ): Deser[(T, PureSerializerState)] = {
+    val mutableState                         = SerializerState.create
+    mutableState.resetTo(state)
+    implicit val ctx: DeserializationContext = DeserializationContext(env, mutableState)
+    try {
+      val result = deserializer.deserialize()
+      finishDeserializerWith((result, mutableState.toPure))
+    } catch {
+      case DesertException(e) => ZPure.fail(e)
+    }
+  }
+
+  final def readUnknown(): Deser[Any] =
+    for {
+      typeRegistry <- getInputTypeRegistry
+      typeId       <- readVarInt(optimizeForPositive = true).map(RegisteredTypeId.apply)
+      result       <- typeRegistry.forId(typeId) match {
+                        case Some(registration) =>
+                          for {
+                            state             <- getDeserializerState
+                            env               <- getDeserializationEnv
+                            pair              <- runUnsafeDeserializer(state, env, registration.codec)
+                            (result, newState) = pair
+                            _                 <- setDeserializerState(newState)
+                          } yield result
+                        case None               =>
+                          failDeserializerWith(DesertFailure.InvalidTypeId(typeId))
+                      }
+    } yield result
+
+  final def finishDeserializerWith[T](value: T): Deser[T]                    = Deser.fromEither(Right(value))
+  final def failDeserializerWith[T](failure: DesertFailure): Deser[T]        = Deser.fromEither(Left(failure))
+  final def deserializerFromTry[T](f: Try[T], failMessage: String): Deser[T] =
+    Deser.fromEither(f.toEither.left.map(failure => DesertFailure.DeserializationFailure(failMessage, Some(failure))))
+
+  final def getString(value: StringId): Deser[Option[String]] =
+    for {
+      state <- getDeserializerState
+    } yield state.stringsById.get(value)
+
+  final def storeReadString(value: String): Deser[Unit] =
+    for {
+      state        <- getDeserializerState
+      (newState, _) = state.storeString(value)
+      _            <- setDeserializerState(newState)
+    } yield ()
+
+  final def getRef(value: RefId): Deser[Option[AnyRef]] =
+    for {
+      state <- getDeserializerState
+    } yield state.refsById.get(value)
+
+  final def storeReadRef(value: AnyRef): Deser[Unit] =
+    for {
+      state        <- getDeserializerState
+      (newState, _) = state.storeRef(value)
+      _            <- setDeserializerState(newState)
+    } yield ()
+
+  def readRefOrValue[T <: AnyRef](storeReadReference: Boolean = true)(implicit codec: BinaryCodec[T]): Deser[T] =
+    readVarInt(optimizeForPositive = true).flatMap {
+      case 0  =>
+        for {
+          value <- read[T]()
+          _     <- if (storeReadReference) storeReadRef(value) else finishDeserializerWith(())
+        } yield value
+      case id =>
+        getRef(RefId(id)).flatMap {
+          case None        => failDeserializerWith(DesertFailure.InvalidRefId(RefId(id)))
+          case Some(value) => finishDeserializerWith(value.asInstanceOf[T])
+        }
+    }
+}

--- a/desert-core/src/main/scala/io/github/vigoo/desert/custom/pure/PureBinaryDeserializerOps.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/custom/pure/PureBinaryDeserializerOps.scala
@@ -1,12 +1,8 @@
 package io.github.vigoo.desert.custom.pure
 
 import io.github.vigoo.desert.TypeRegistry.RegisteredTypeId
-import io.github.vigoo.desert.internal.{
-  DeserializationContext,
-  DeserializationEnv,
-  PureSerializerState,
-  SerializerState
-}
+import io.github.vigoo.desert.custom.DeserializationContext
+import io.github.vigoo.desert.internal.{DeserializationEnv, PureSerializerState, SerializerState}
 import io.github.vigoo.desert.internal.SerializerState.{RefId, StringId}
 import io.github.vigoo.desert.{
   BinaryCodec,
@@ -14,7 +10,8 @@ import io.github.vigoo.desert.{
   BinaryInput,
   DesertException,
   DesertFailure,
-  TypeRegistry
+  TypeRegistry,
+  custom
 }
 import zio.prelude.fx.ZPure
 
@@ -56,7 +53,7 @@ trait PureBinaryDeserializerOps {
   ): Deser[(T, PureSerializerState)] = {
     val mutableState                         = SerializerState.create
     mutableState.resetTo(state)
-    implicit val ctx: DeserializationContext = DeserializationContext(env, mutableState)
+    implicit val ctx: DeserializationContext = custom.DeserializationContext(env, mutableState)
     try {
       val result = deserializer.deserialize()
       finishDeserializerWith((result, mutableState.toPure))

--- a/desert-core/src/main/scala/io/github/vigoo/desert/custom/pure/PureBinarySerializerOps.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/custom/pure/PureBinarySerializerOps.scala
@@ -1,6 +1,7 @@
 package io.github.vigoo.desert.custom.pure
 
-import io.github.vigoo.desert.internal.{PureSerializerState, SerializationContext, SerializationEnv, SerializerState}
+import io.github.vigoo.desert.custom.SerializationContext
+import io.github.vigoo.desert.internal.{PureSerializerState, SerializationEnv, SerializerState}
 import io.github.vigoo.desert.internal.SerializerState.{RefAlreadyStored, RefIsNew, StoreRefResult, StoreStringResult}
 import io.github.vigoo.desert.{
   BinaryCodec,
@@ -8,7 +9,8 @@ import io.github.vigoo.desert.{
   BinarySerializer,
   DesertException,
   DesertFailure,
-  TypeRegistry
+  TypeRegistry,
+  custom
 }
 import zio.prelude.fx.ZPure
 
@@ -68,7 +70,7 @@ trait PureBinarySerializerOps {
   ): Ser[PureSerializerState] = {
     val mutableState                       = SerializerState.create
     mutableState.resetTo(state)
-    implicit val ctx: SerializationContext = SerializationContext(env, mutableState)
+    implicit val ctx: SerializationContext = custom.SerializationContext(env, mutableState)
     try {
       serializer.serialize(value)
       finishSerializerWith(mutableState.toPure)

--- a/desert-core/src/main/scala/io/github/vigoo/desert/custom/pure/PureBinarySerializerOps.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/custom/pure/PureBinarySerializerOps.scala
@@ -1,0 +1,105 @@
+package io.github.vigoo.desert.custom.pure
+
+import io.github.vigoo.desert.internal.{PureSerializerState, SerializationContext, SerializationEnv, SerializerState}
+import io.github.vigoo.desert.internal.SerializerState.{RefAlreadyStored, RefIsNew, StoreRefResult, StoreStringResult}
+import io.github.vigoo.desert.{
+  BinaryCodec,
+  BinaryOutput,
+  BinarySerializer,
+  DesertException,
+  DesertFailure,
+  TypeRegistry
+}
+import zio.prelude.fx.ZPure
+
+import java.util.zip.Deflater
+import scala.util.Try
+
+trait PureBinarySerializerOps {
+  final def getOutput: Ser[BinaryOutput]                              = ZPure.serviceWith(_.output)
+  final def getOutputTypeRegistry: Ser[TypeRegistry]                  = ZPure.serviceWith(_.typeRegistry)
+  final def getSerializationEnv: Ser[SerializationEnv]                = ZPure.service
+  final def getSerializerState: Ser[PureSerializerState]              = ZPure.get
+  final def setSerializerState(state: PureSerializerState): Ser[Unit] = ZPure.set(state)
+
+  final def writeByte(value: Byte): Ser[Unit]                                                     = getOutput.flatMap(output => Ser.attempt(output.writeByte(value)))
+  final def writeShort(value: Short): Ser[Unit]                                                   = getOutput.flatMap(output => Ser.attempt(output.writeShort(value)))
+  final def writeInt(value: Int): Ser[Unit]                                                       = getOutput.flatMap(output => Ser.attempt(output.writeInt(value)))
+  final def writeVarInt(value: Int, optimizeForPositive: Boolean): Ser[Unit]                      =
+    getOutput.flatMap(output => Ser.attempt(output.writeVarInt(value, optimizeForPositive)))
+  final def writeLong(value: Long): Ser[Unit]                                                     = getOutput.flatMap(output => Ser.attempt(output.writeLong(value)))
+  final def writeFloat(value: Float): Ser[Unit]                                                   = getOutput.flatMap(output => Ser.attempt(output.writeFloat(value)))
+  final def writeDouble(value: Double): Ser[Unit]                                                 =
+    getOutput.flatMap(output => Ser.attempt(output.writeDouble(value)))
+  final def writeBytes(value: Array[Byte]): Ser[Unit]                                             =
+    getOutput.flatMap(output => Ser.attempt(output.writeBytes(value)))
+  final def writeCompressedBytes(value: Array[Byte], level: Int = Deflater.BEST_SPEED): Ser[Unit] =
+    getOutput.flatMap(output => Ser.attempt(output.writeCompressedByteArray(value, level)))
+
+  final def writeUnknown(value: Any): Ser[Unit] =
+    getOutputTypeRegistry.flatMap { typeRegistry =>
+      typeRegistry.get(value) match {
+        case Some(registration) =>
+          for {
+            _        <- writeVarInt(registration.id.value, optimizeForPositive = true)
+            state    <- getSerializerState
+            env      <- getSerializationEnv
+            newState <- runUnsafeSerializer(state, env, registration.codec.asInstanceOf[BinarySerializer[Any]], value)
+            _        <- setSerializerState(newState)
+          } yield ()
+        case None               =>
+          failSerializerWith(DesertFailure.TypeNotRegistered(value.getClass))
+      }
+    }
+
+  final def write[U: BinarySerializer](value: U): Ser[Unit] =
+    for {
+      state    <- getSerializerState
+      env      <- getSerializationEnv
+      newState <- runUnsafeSerializer(state, env, implicitly[BinarySerializer[U]], value)
+      _        <- setSerializerState(newState)
+    } yield ()
+
+  private def runUnsafeSerializer[T](
+      state: PureSerializerState,
+      env: SerializationEnv,
+      serializer: BinarySerializer[T],
+      value: T
+  ): Ser[PureSerializerState] = {
+    val mutableState                       = SerializerState.create
+    mutableState.resetTo(state)
+    implicit val ctx: SerializationContext = SerializationContext(env, mutableState)
+    try {
+      serializer.serialize(value)
+      finishSerializerWith(mutableState.toPure)
+    } catch {
+      case DesertException(e) => ZPure.fail(e)
+    }
+  }
+
+  final def finishSerializer(): Ser[Unit]                                  = finishSerializerWith(())
+  final def finishSerializerWith[T](value: T): Ser[T]                      = Ser.fromEither(Right(value))
+  final def failSerializerWith(failure: DesertFailure): Ser[Unit]          = Ser.fromEither(Left(failure))
+  final def serializerFromTry[T](f: Try[T], failMessage: String): Deser[T] =
+    Deser.fromEither(f.toEither.left.map(failure => DesertFailure.SerializationFailure(failMessage, Some(failure))))
+
+  final def storeString(value: String): Ser[StoreStringResult] =
+    for {
+      state             <- getSerializerState
+      (newState, result) = state.storeString(value)
+      _                 <- setSerializerState(newState)
+    } yield result
+
+  final def storeRef(value: AnyRef): Ser[StoreRefResult] =
+    for {
+      state             <- getSerializerState
+      (newState, result) = state.storeRef(value)
+      _                 <- setSerializerState(newState)
+    } yield result
+
+  final def storeRefOrObject[T <: AnyRef](value: T)(implicit codec: BinaryCodec[T]): Ser[Unit] =
+    storeRef(value).flatMap {
+      case RefAlreadyStored(id) => writeVarInt(id.value, optimizeForPositive = true)
+      case RefIsNew(_)          => writeVarInt(0, optimizeForPositive = true) *> write(value)
+    }
+}

--- a/desert-core/src/main/scala/io/github/vigoo/desert/custom/pure/package.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/custom/pure/package.scala
@@ -1,0 +1,35 @@
+package io.github.vigoo.desert.custom
+
+import io.github.vigoo.desert.{DesertException, DesertFailure}
+import io.github.vigoo.desert.internal.{DeserializationEnv, PureSerializerState, SerializationEnv}
+import zio.prelude.fx.ZPure
+
+package object pure extends PureBinarySerializerOps with PureBinaryDeserializerOps {
+
+  type Ser[T] = ZPure[Nothing, PureSerializerState, PureSerializerState, SerializationEnv, DesertFailure, T]
+
+  object Ser {
+    final def fromEither[T](value: Either[DesertFailure, T]): Ser[T] =
+      ZPure.succeed(value).absolve
+
+    final def attempt[T](value: => T): Ser[T] =
+      try
+        ZPure.succeed(value)
+      catch {
+        case DesertException(e) => ZPure.fail(e)
+      }
+  }
+
+  type Deser[T] = ZPure[Nothing, PureSerializerState, PureSerializerState, DeserializationEnv, DesertFailure, T]
+
+  object Deser {
+    final def fromEither[T](value: Either[DesertFailure, T]): Deser[T] =
+      ZPure.succeed(value).absolve
+
+    final def attempt[T](value: => T): Deser[T] =
+      try ZPure.succeed(value)
+      catch {
+        case DesertException(e) => ZPure.fail(e)
+      }
+  }
+}

--- a/desert-core/src/main/scala/io/github/vigoo/desert/internal/AdtCodec.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/internal/AdtCodec.scala
@@ -1,6 +1,6 @@
 package io.github.vigoo.desert.internal
 
-import io.github.vigoo.desert._
+import io.github.vigoo.desert.{custom, _}
 import io.github.vigoo.desert.Evolution._
 import io.github.vigoo.desert.custom._
 
@@ -462,7 +462,7 @@ object AdtCodec {
     final def getSerializationContext(output: BinaryOutput)(implicit
         ctx: ChunkedSerializationContext
     ): SerializationContext =
-      SerializationContext(SerializationEnv(output, ctx.state.typeRegistry), ctx.state.serializerState)
+      custom.SerializationContext(SerializationEnv(output, ctx.state.typeRegistry), ctx.state.serializerState)
 
     final def recordFieldIndex(fieldName: String, chunk: Byte)(implicit ctx: ChunkedSerializationContext): Unit =
       ctx.state.getLastIndexPerChunk(chunk) match {
@@ -493,7 +493,7 @@ object AdtCodec {
     final def toDeserializationContext(input: BinaryInput)(implicit
         ctx: ChunkedDeserializationContext
     ): DeserializationContext =
-      DeserializationContext(DeserializationEnv(input, ctx.state.typeRegistry), ctx.state.serializerState)
+      custom.DeserializationContext(DeserializationEnv(input, ctx.state.typeRegistry), ctx.state.serializerState)
 
     final def recordFieldIndex(fieldName: String, chunk: Byte)(implicit
         ctx: ChunkedDeserializationContext

--- a/desert-core/src/main/scala/io/github/vigoo/desert/internal/DeserializationContext.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/internal/DeserializationContext.scala
@@ -1,3 +1,0 @@
-package io.github.vigoo.desert.internal
-
-final case class DeserializationContext(env: DeserializationEnv, state: SerializerState)

--- a/desert-core/src/main/scala/io/github/vigoo/desert/internal/DeserializationContext.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/internal/DeserializationContext.scala
@@ -1,0 +1,3 @@
+package io.github.vigoo.desert.internal
+
+final case class DeserializationContext(env: DeserializationEnv, state: SerializerState)

--- a/desert-core/src/main/scala/io/github/vigoo/desert/internal/JavaStreamBinaryOutput.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/internal/JavaStreamBinaryOutput.scala
@@ -1,46 +1,48 @@
 package io.github.vigoo.desert.internal
 
-import io.github.vigoo.desert.{BinaryOutput, DesertFailure}
+import io.github.vigoo.desert.{BinaryOutput, DesertException, DesertFailure}
 
 import java.io.{DataOutputStream, OutputStream}
-import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
 
 final class JavaStreamBinaryOutput(stream: OutputStream) extends BinaryOutput {
   private val buffer: Array[Byte] = new Array[Byte](4)
   private val dataStream          = new DataOutputStream(stream)
 
-  override def writeByte(value: Byte): Either[DesertFailure, Unit] =
-    handleFailures(dataStream.writeByte(value))
+  override def writeByte(value: Byte): Unit =
+    try dataStream.writeByte(value)
+    catch { case NonFatal(e) => throw new DesertException(DesertFailure.FailedToWriteOutput(e)) }
 
-  override def writeShort(value: Short): Either[DesertFailure, Unit] =
-    handleFailures(dataStream.writeShort(value))
+  override def writeShort(value: Short): Unit =
+    try dataStream.writeShort(value)
+    catch { case NonFatal(e) => throw new DesertException(DesertFailure.FailedToWriteOutput(e)) }
 
-  override def writeInt(value: Int): Either[DesertFailure, Unit] = {
+  override def writeInt(value: Int): Unit = {
     buffer(0) = ((value >>> 24) & 0xff).toByte
     buffer(1) = ((value >>> 16) & 0xff).toByte
     buffer(2) = ((value >>> 8) & 0xff).toByte
     buffer(3) = ((value >>> 0) & 0xff).toByte
-    handleFailures(dataStream.write(buffer))
+    try dataStream.write(buffer)
+    catch { case NonFatal(e) => throw new DesertException(DesertFailure.FailedToWriteOutput(e)) }
   }
 
-  override def writeLong(value: Long): Either[DesertFailure, Unit] =
-    handleFailures(dataStream.writeLong(value))
+  override def writeLong(value: Long): Unit =
+    try dataStream.writeLong(value)
+    catch { case NonFatal(e) => throw new DesertException(DesertFailure.FailedToWriteOutput(e)) }
 
-  override def writeFloat(value: Float): Either[DesertFailure, Unit] =
-    handleFailures(dataStream.writeFloat(value))
+  override def writeFloat(value: Float): Unit =
+    try dataStream.writeFloat(value)
+    catch { case NonFatal(e) => throw new DesertException(DesertFailure.FailedToWriteOutput(e)) }
 
-  override def writeDouble(value: Double): Either[DesertFailure, Unit] =
-    handleFailures(dataStream.writeDouble(value))
+  override def writeDouble(value: Double): Unit =
+    try dataStream.writeDouble(value)
+    catch { case NonFatal(e) => throw new DesertException(DesertFailure.FailedToWriteOutput(e)) }
 
-  override def writeBytes(value: Array[Byte]): Either[DesertFailure, Unit] =
-    handleFailures(dataStream.write(value))
+  override def writeBytes(value: Array[Byte]): Unit =
+    try dataStream.write(value)
+    catch { case NonFatal(e) => throw new DesertException(DesertFailure.FailedToWriteOutput(e)) }
 
-  override def writeBytes(value: Array[Byte], start: Int, count: Int): Either[DesertFailure, Unit] =
-    handleFailures(dataStream.write(value, start, count))
-
-  private def handleFailures[T](f: => T): Either[DesertFailure, T] =
-    Try(f) match {
-      case Success(value)  => Right(value)
-      case Failure(reason) => Left(DesertFailure.FailedToWriteOutput(reason))
-    }
+  override def writeBytes(value: Array[Byte], start: Int, count: Int): Unit =
+    try dataStream.write(value, start, count)
+    catch { case NonFatal(e) => throw new DesertException(DesertFailure.FailedToWriteOutput(e)) }
 }

--- a/desert-core/src/main/scala/io/github/vigoo/desert/internal/OptionBinaryCodec.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/internal/OptionBinaryCodec.scala
@@ -1,0 +1,20 @@
+package io.github.vigoo.desert.internal
+
+import io.github.vigoo.desert.BinaryCodec
+import io.github.vigoo.desert.custom.{read, write}
+
+private[desert] final case class OptionBinaryCodec[T]()(implicit val innerCodec: BinaryCodec[T])
+    extends BinaryCodec[Option[T]] {
+
+  override def deserialize()(implicit ctx: DeserializationContext): Option[T] =
+    if (read[Boolean]()) Some(read[T]()) else None
+
+  override def serialize(value: Option[T])(implicit context: SerializationContext): Unit =
+    value match {
+      case Some(value) =>
+        write(true)
+        write(value)
+      case None        =>
+        write(false)
+    }
+}

--- a/desert-core/src/main/scala/io/github/vigoo/desert/internal/OptionBinaryCodec.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/internal/OptionBinaryCodec.scala
@@ -1,7 +1,7 @@
 package io.github.vigoo.desert.internal
 
 import io.github.vigoo.desert._
-import io.github.vigoo.desert.custom.{read, write}
+import io.github.vigoo.desert.custom.{DeserializationContext, SerializationContext, read, write}
 
 private[desert] final case class OptionBinaryCodec[T]()(implicit val innerCodec: BinaryCodec[T])
     extends BinaryCodec[Option[T]] {

--- a/desert-core/src/main/scala/io/github/vigoo/desert/internal/OptionBinaryCodec.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/internal/OptionBinaryCodec.scala
@@ -1,6 +1,6 @@
 package io.github.vigoo.desert.internal
 
-import io.github.vigoo.desert.BinaryCodec
+import io.github.vigoo.desert._
 import io.github.vigoo.desert.custom.{read, write}
 
 private[desert] final case class OptionBinaryCodec[T]()(implicit val innerCodec: BinaryCodec[T])

--- a/desert-core/src/main/scala/io/github/vigoo/desert/internal/PureSerializerState.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/internal/PureSerializerState.scala
@@ -1,0 +1,43 @@
+package io.github.vigoo.desert.internal
+
+import io.github.vigoo.desert.internal.SerializerState._
+
+case class PureSerializerState(
+    stringsById: Map[StringId, String],
+    idsByString: Map[String, StringId],
+    refsById: Map[RefId, AnyRef],
+    idsByRef: Map[AnyRef, RefId],
+    lastStringId: StringId,
+    lastRefId: RefId
+) {
+
+  def storeString(value: String): (PureSerializerState, StoreStringResult) =
+    idsByString.get(value) match {
+      case Some(id) => (this, StringAlreadyStored(id))
+      case None     =>
+        val id = lastStringId.next
+        (
+          copy(
+            stringsById = stringsById + (id    -> value),
+            idsByString = idsByString + (value -> id),
+            lastStringId = id
+          ),
+          StringIsNew(id)
+        )
+    }
+
+  def storeRef(value: AnyRef): (PureSerializerState, StoreRefResult) =
+    idsByRef.get(value) match {
+      case Some(id) => (this, RefAlreadyStored(id))
+      case None     =>
+        val id = lastRefId.next
+        (
+          copy(
+            refsById = refsById + (id    -> value),
+            idsByRef = idsByRef + (value -> id),
+            lastRefId = id
+          ),
+          RefIsNew(id)
+        )
+    }
+}

--- a/desert-core/src/main/scala/io/github/vigoo/desert/internal/SerializationContext.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/internal/SerializationContext.scala
@@ -1,3 +1,0 @@
-package io.github.vigoo.desert.internal
-
-final case class SerializationContext(env: SerializationEnv, state: SerializerState)

--- a/desert-core/src/main/scala/io/github/vigoo/desert/internal/SerializationContext.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/internal/SerializationContext.scala
@@ -1,0 +1,3 @@
+package io.github.vigoo.desert.internal
+
+final case class SerializationContext(env: SerializationEnv, state: SerializerState)

--- a/desert-core/src/main/scala/io/github/vigoo/desert/package.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/package.scala
@@ -1,21 +1,3 @@
 package io.github.vigoo
 
-import io.github.vigoo.desert.internal.{DeserializationEnv, SerializationEnv, SerializerState}
-import zio.prelude.fx.ZPure
-
-package object desert extends BinarySerialization with Codecs {
-
-  type Ser[T] = ZPure[Nothing, SerializerState, SerializerState, SerializationEnv, DesertFailure, T]
-
-  object Ser {
-    final def fromEither[T](value: Either[DesertFailure, T]): Ser[T] =
-      ZPure.succeed(value).absolve
-  }
-
-  type Deser[T] = ZPure[Nothing, SerializerState, SerializerState, DeserializationEnv, DesertFailure, T]
-
-  object Deser {
-    final def fromEither[T](value: Either[DesertFailure, T]): Deser[T] =
-      ZPure.succeed(value).absolve
-  }
-}
+package object desert extends BinarySerialization with Codecs {}

--- a/desert-core/src/test/scala/io/github/vigoo/desert/JavaStreamInputOutputSpec.scala
+++ b/desert-core/src/test/scala/io/github/vigoo/desert/JavaStreamInputOutputSpec.scala
@@ -1,10 +1,9 @@
 package io.github.vigoo.desert
 
 import io.github.vigoo.desert.internal.{JavaStreamBinaryInput, JavaStreamBinaryOutput}
+import zio.test._
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-import zio.test.Assertion._
-import zio.test._
 
 object JavaStreamInputOutputSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment, Any] =
@@ -31,7 +30,7 @@ object JavaStreamInputOutputSpec extends ZIOSpecDefault {
           check(Gen.vectorOf(Gen.byte)) { bytes =>
             testWriteAndRead(
               _.writeCompressedByteArray(bytes.toArray),
-              _.readCompressedByteArray().map(_.toVector),
+              _.readCompressedByteArray().toVector,
               bytes
             )
           }
@@ -41,7 +40,7 @@ object JavaStreamInputOutputSpec extends ZIOSpecDefault {
 
   private def testWriteAndRead[T](
       write: BinaryOutput => Unit,
-      read: BinaryInput => Either[DesertFailure, T],
+      read: BinaryInput => T,
       expected: T
   ): TestResult = {
     val outStream = new ByteArrayOutputStream()
@@ -54,6 +53,6 @@ object JavaStreamInputOutputSpec extends ZIOSpecDefault {
     val input     = new JavaStreamBinaryInput(inStream)
     val readValue = read(input)
 
-    assert(readValue)(isRight(equalTo(expected)))
+    assertTrue(readValue == expected)
   }
 }

--- a/desert-core/src/test/scala/io/github/vigoo/desert/ReferenceTrackingSpec.scala
+++ b/desert-core/src/test/scala/io/github/vigoo/desert/ReferenceTrackingSpec.scala
@@ -1,7 +1,6 @@
 package io.github.vigoo.desert
 
 import io.github.vigoo.desert.custom._
-import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
 import zio.test.Assertion._
 import zio.test._
 

--- a/desert-shapeless/src/main/scala/io/github/vigoo/desert/shapeless/GenericBinaryCodec.scala
+++ b/desert-shapeless/src/main/scala/io/github/vigoo/desert/shapeless/GenericBinaryCodec.scala
@@ -561,7 +561,7 @@ class GenericBinaryCodec(evolutionSteps: Vector[Evolution]) extends GenericDeriv
     val constructorMap  = toConstructorMap.value.constructors
     val trs             = zip(keys.value() :: transientAnnotations() :: HNil)
     val transientFields = toList(trs).collect { case (key, Some(transientField(defaultValue))) =>
-      (key, defaultValue)
+      (key.name, defaultValue)
     }.toMap
 
     new AdtCodec[T, BuilderState](
@@ -574,7 +574,7 @@ class GenericBinaryCodec(evolutionSteps: Vector[Evolution]) extends GenericDeriv
         serializationPlan.value.commands(taggedTransients.tag(genericValue))
       },
       deserializationPlan.value.commands,
-      BuilderState.empty,
+      () => BuilderState.empty,
       (values => Right(gen.from(taggedTransients.untag(deserializationPlan.value.materialize(values)))))
     )
   }

--- a/desert-shapeless/src/main/scala/io/github/vigoo/desert/shapeless/UnwrappedBinaryCodec.scala
+++ b/desert-shapeless/src/main/scala/io/github/vigoo/desert/shapeless/UnwrappedBinaryCodec.scala
@@ -2,6 +2,7 @@ package io.github.vigoo.desert.shapeless
 
 import io.github.vigoo.desert._
 import _root_.shapeless._
+import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
 
 abstract class UnwrappedBinaryCodec[T] extends BinaryCodec[T]
 
@@ -11,7 +12,10 @@ object UnwrappedBinaryCodec {
       codec: BinaryCodec[R]
   ): UnwrappedBinaryCodec[A] =
     new UnwrappedBinaryCodec[A] {
-      override def deserialize(): Deser[A]        = codec.map(r => gen.value.from(r :: HNil)).deserialize()
-      override def serialize(value: A): Ser[Unit] = codec.contramap((a: A) => gen.value.to(a).head).serialize(value)
+      override def deserialize()(implicit ctx: DeserializationContext): A =
+        gen.value.from(codec.deserialize() :: HNil)
+
+      override def serialize(value: A)(implicit context: SerializationContext): Unit =
+        codec.serialize(gen.value.to(value).head)
     }
 }

--- a/desert-shapeless/src/main/scala/io/github/vigoo/desert/shapeless/UnwrappedBinaryCodec.scala
+++ b/desert-shapeless/src/main/scala/io/github/vigoo/desert/shapeless/UnwrappedBinaryCodec.scala
@@ -2,7 +2,7 @@ package io.github.vigoo.desert.shapeless
 
 import io.github.vigoo.desert._
 import _root_.shapeless._
-import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
+import io.github.vigoo.desert.custom.{DeserializationContext, SerializationContext}
 
 abstract class UnwrappedBinaryCodec[T] extends BinaryCodec[T]
 

--- a/desert-shapeless/src/test/scala/io/github/vigoo/desert/shapeless/DefaultTypeRegistrySpec.scala
+++ b/desert-shapeless/src/test/scala/io/github/vigoo/desert/shapeless/DefaultTypeRegistrySpec.scala
@@ -2,6 +2,7 @@ package io.github.vigoo.desert.shapeless
 
 import io.github.vigoo.desert.TypeRegistry.RegisteredTypeId
 import io.github.vigoo.desert._
+import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
 import zio.test._
 import zio.test.Assertion._
 
@@ -18,17 +19,23 @@ object DefaultTypeRegistrySpec extends ZIOSpecDefault {
     import io.github.vigoo.desert.custom._
 
     implicit val codec: BinaryCodec[TestInterface] =
-      BinaryCodec.define[TestInterface] {
-        case _: Impl1 => writeByte(1)
-        case _: Impl2 => writeByte(2)
-      }(readByte().flatMap {
-        case 1 => finishDeserializerWith(new Impl1)
-        case 2 => finishDeserializerWith(new Impl2)
-        case _ =>
-          failDeserializerWith(
-            DesertFailure.DeserializationFailure("Invalid type tag in custom TestInterface serializer", None)
-          )
-      })
+      new BinaryCodec[TestInterface] {
+        override def deserialize()(implicit ctx: DeserializationContext): TestInterface =
+          readByte() match {
+            case 1 => new Impl1
+            case 2 => new Impl2
+            case _ =>
+              throw DesertException(
+                DesertFailure.DeserializationFailure("Invalid type tag in custom TestInterface serializer", None)
+              )
+          }
+
+        override def serialize(value: TestInterface)(implicit context: SerializationContext): Unit =
+          value match {
+            case _: Impl1 => writeByte(1)
+            case _: Impl2 => writeByte(2)
+          }
+      }
   }
 
   implicit val codec: BinaryCodec[TestProd] = DerivedBinaryCodec.derive

--- a/desert-shapeless/src/test/scala/io/github/vigoo/desert/shapeless/DefaultTypeRegistrySpec.scala
+++ b/desert-shapeless/src/test/scala/io/github/vigoo/desert/shapeless/DefaultTypeRegistrySpec.scala
@@ -2,7 +2,7 @@ package io.github.vigoo.desert.shapeless
 
 import io.github.vigoo.desert.TypeRegistry.RegisteredTypeId
 import io.github.vigoo.desert._
-import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
+import io.github.vigoo.desert.custom.{DeserializationContext, SerializationContext}
 import zio.test._
 import zio.test.Assertion._
 

--- a/desert-shapeless/src/test/scala/io/github/vigoo/desert/shapeless/StringDeduplicationSpec.scala
+++ b/desert-shapeless/src/test/scala/io/github/vigoo/desert/shapeless/StringDeduplicationSpec.scala
@@ -4,11 +4,9 @@ import io.github.vigoo.desert.Evolution.FieldAdded
 import io.github.vigoo.desert._
 import io.github.vigoo.desert.custom._
 import io.github.vigoo.desert.internal.{
-  DeserializationContext,
   DeserializationEnv,
   JavaStreamBinaryInput,
   JavaStreamBinaryOutput,
-  SerializationContext,
   SerializationEnv,
   SerializerState
 }
@@ -61,13 +59,13 @@ object StringDeduplicationSpec extends ZIOSpecDefault with SerializationProperti
         val stream                                = new ByteArrayOutputStream()
         val output                                = new JavaStreamBinaryOutput(stream)
         implicit val sctx: SerializationContext   =
-          SerializationContext(SerializationEnv(output, TypeRegistry.empty), SerializerState.create)
+          custom.SerializationContext(SerializationEnv(output, TypeRegistry.empty), SerializerState.create)
         testSer
         stream.flush()
         val inStream                              = new ByteArrayInputStream(stream.toByteArray)
         val input                                 = new JavaStreamBinaryInput(inStream)
         implicit val dctx: DeserializationContext =
-          DeserializationContext(DeserializationEnv(input, TypeRegistry.empty), SerializerState.create)
+          custom.DeserializationContext(DeserializationEnv(input, TypeRegistry.empty), SerializerState.create)
         val result                                = testDeser
 
         assertTrue(result == List(s1, s2, s3, s1, s2, s3))
@@ -76,7 +74,7 @@ object StringDeduplicationSpec extends ZIOSpecDefault with SerializationProperti
         val stream                              = new ByteArrayOutputStream()
         val output                              = new JavaStreamBinaryOutput(stream)
         implicit val sctx: SerializationContext =
-          SerializationContext(SerializationEnv(output, TypeRegistry.empty), SerializerState.create)
+          custom.SerializationContext(SerializationEnv(output, TypeRegistry.empty), SerializerState.create)
         testSer
         val size                                = stream.toByteArray.length
 

--- a/desert-zio-schema/src/test/scala/io/github/vigoo/desert/zioschema/DefaultTypeRegistrySpec.scala
+++ b/desert-zio-schema/src/test/scala/io/github/vigoo/desert/zioschema/DefaultTypeRegistrySpec.scala
@@ -2,7 +2,7 @@ package io.github.vigoo.desert.zioschema
 
 import io.github.vigoo.desert.TypeRegistry.RegisteredTypeId
 import io.github.vigoo.desert._
-import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
+import io.github.vigoo.desert.custom.{DeserializationContext, SerializationContext}
 import zio.schema.{DeriveSchema, Schema}
 import zio.test.Assertion.{equalTo, isNone, isSome}
 import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assert}

--- a/desert-zio-schema/src/test/scala/io/github/vigoo/desert/zioschema/StringDeduplicationSpec.scala
+++ b/desert-zio-schema/src/test/scala/io/github/vigoo/desert/zioschema/StringDeduplicationSpec.scala
@@ -1,18 +1,10 @@
 package io.github.vigoo.desert.zioschema
 
-import io.github.vigoo.desert._
 import io.github.vigoo.desert.Evolution._
 import io.github.vigoo.desert.custom._
-import io.github.vigoo.desert.internal.{
-  DeserializationEnv,
-  JavaStreamBinaryInput,
-  JavaStreamBinaryOutput,
-  SerializationEnv,
-  SerializerState
-}
-import io.github.vigoo.desert.{SerializationProperties, TypeRegistry, evolutionSteps}
+import io.github.vigoo.desert.internal._
+import io.github.vigoo.desert._
 import zio.schema.{DeriveSchema, Schema}
-import zio.test.Assertion.{equalTo, isLessThan, isRight}
 import zio.test._
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
@@ -31,25 +23,6 @@ object StringDeduplicationSpec extends ZIOSpecDefault with SerializationProperti
   val s2 = "and another one"
   val s3 = "and another one"
 
-  private val testSer: Ser[Unit] = for {
-    _ <- write(DeduplicatedString(s1))
-    _ <- write(DeduplicatedString(s2))
-    _ <- write(DeduplicatedString(s3))
-    _ <- write(DeduplicatedString(s1))
-    _ <- write(DeduplicatedString(s2))
-    _ <- write(DeduplicatedString(s3))
-  } yield ()
-
-  private val testDeser: Deser[List[String]] =
-    for {
-      a <- read[DeduplicatedString]()
-      b <- read[DeduplicatedString]()
-      c <- read[DeduplicatedString]()
-      d <- read[DeduplicatedString]()
-      e <- read[DeduplicatedString]()
-      f <- read[DeduplicatedString]()
-    } yield List(a, b, c, d, e, f).map(_.string)
-
   implicit val v1Schema: Schema[DataV1]       = DeriveSchema.gen
   implicit val v2Schema: Schema[DataV2]       = DeriveSchema.gen
   implicit val outerv1Schema: Schema[OuterV1] = DeriveSchema.gen
@@ -60,40 +33,51 @@ object StringDeduplicationSpec extends ZIOSpecDefault with SerializationProperti
   implicit val outerv1codec: BinaryCodec[OuterV1] = DerivedBinaryCodec.derive
   implicit val outerv2codec: BinaryCodec[OuterV2] = DerivedBinaryCodec.derive
 
+  private def testSer(implicit ctx: SerializationContext): Unit = {
+    write(DeduplicatedString(s1))
+    write(DeduplicatedString(s2))
+    write(DeduplicatedString(s3))
+    write(DeduplicatedString(s1))
+    write(DeduplicatedString(s2))
+    write(DeduplicatedString(s3))
+  }
+
+  private def testDeser(implicit ctx: DeserializationContext): List[String] =
+    List(
+      read[DeduplicatedString](),
+      read[DeduplicatedString](),
+      read[DeduplicatedString](),
+      read[DeduplicatedString](),
+      read[DeduplicatedString](),
+      read[DeduplicatedString]()
+    ).map(_.string)
+
   override def spec: Spec[TestEnvironment, Any] =
     suite("String deduplication")(
       test("reads back duplicated strings correctly") {
-        val stream = new ByteArrayOutputStream()
-        val output = new JavaStreamBinaryOutput(stream)
-        val result = testSer
-          .provideService(SerializationEnv(output, TypeRegistry.empty))
-          .either
-          .runResult(SerializerState.initial)
-          .flatMap { _ =>
-            stream.flush()
-            val inStream = new ByteArrayInputStream(stream.toByteArray)
-            val input    = new JavaStreamBinaryInput(inStream)
-            testDeser
-              .provideService(DeserializationEnv(input, TypeRegistry.empty))
-              .either
-              .runResult(SerializerState.initial)
-          }
+        val stream                                = new ByteArrayOutputStream()
+        val output                                = new JavaStreamBinaryOutput(stream)
+        implicit val sctx: SerializationContext   =
+          SerializationContext(SerializationEnv(output, TypeRegistry.empty), SerializerState.create)
+        testSer
+        stream.flush()
+        val inStream                              = new ByteArrayInputStream(stream.toByteArray)
+        val input                                 = new JavaStreamBinaryInput(inStream)
+        implicit val dctx: DeserializationContext =
+          DeserializationContext(DeserializationEnv(input, TypeRegistry.empty), SerializerState.create)
+        val result                                = testDeser
 
-        assert(result)(isRight(equalTo(List(s1, s2, s3, s1, s2, s3))))
+        assertTrue(result == List(s1, s2, s3, s1, s2, s3))
       },
       test("reduces the serialized size") {
-        val stream = new ByteArrayOutputStream()
-        val output = new JavaStreamBinaryOutput(stream)
-        val size   = testSer
-          .provideService(SerializationEnv(output, TypeRegistry.empty))
-          .either
-          .runResult(SerializerState.initial)
-          .map { _ =>
-            stream.flush()
-            stream.toByteArray.length
-          }
+        val stream                              = new ByteArrayOutputStream()
+        val output                              = new JavaStreamBinaryOutput(stream)
+        implicit val sctx: SerializationContext =
+          SerializationContext(SerializationEnv(output, TypeRegistry.empty), SerializerState.create)
+        testSer
+        val size                                = stream.toByteArray.length
 
-        assert(size)(isRight(isLessThan((s1.length + s2.length) * 2)))
+        assertTrue(size < (s1.length + s2.length) * 2)
       },
       test("default string serialization does not breaks data evolution") {
         implicit val typeRegistry: TypeRegistry = TypeRegistry.empty

--- a/desert-zio-schema/src/test/scala/io/github/vigoo/desert/zioschema/StringDeduplicationSpec.scala
+++ b/desert-zio-schema/src/test/scala/io/github/vigoo/desert/zioschema/StringDeduplicationSpec.scala
@@ -3,7 +3,7 @@ package io.github.vigoo.desert.zioschema
 import io.github.vigoo.desert.Evolution._
 import io.github.vigoo.desert.custom._
 import io.github.vigoo.desert.internal._
-import io.github.vigoo.desert._
+import io.github.vigoo.desert.{custom, _}
 import zio.schema.{DeriveSchema, Schema}
 import zio.test._
 
@@ -58,13 +58,13 @@ object StringDeduplicationSpec extends ZIOSpecDefault with SerializationProperti
         val stream                                = new ByteArrayOutputStream()
         val output                                = new JavaStreamBinaryOutput(stream)
         implicit val sctx: SerializationContext   =
-          SerializationContext(SerializationEnv(output, TypeRegistry.empty), SerializerState.create)
+          custom.SerializationContext(SerializationEnv(output, TypeRegistry.empty), SerializerState.create)
         testSer
         stream.flush()
         val inStream                              = new ByteArrayInputStream(stream.toByteArray)
         val input                                 = new JavaStreamBinaryInput(inStream)
         implicit val dctx: DeserializationContext =
-          DeserializationContext(DeserializationEnv(input, TypeRegistry.empty), SerializerState.create)
+          custom.DeserializationContext(DeserializationEnv(input, TypeRegistry.empty), SerializerState.create)
         val result                                = testDeser
 
         assertTrue(result == List(s1, s2, s3, s1, s2, s3))
@@ -73,7 +73,7 @@ object StringDeduplicationSpec extends ZIOSpecDefault with SerializationProperti
         val stream                              = new ByteArrayOutputStream()
         val output                              = new JavaStreamBinaryOutput(stream)
         implicit val sctx: SerializationContext =
-          SerializationContext(SerializationEnv(output, TypeRegistry.empty), SerializerState.create)
+          custom.SerializationContext(SerializationEnv(output, TypeRegistry.empty), SerializerState.create)
         testSer
         val size                                = stream.toByteArray.length
 

--- a/desert-zio/src/main/scala/io/github/vigoo/desert/ziosupport/Codecs.scala
+++ b/desert-zio/src/main/scala/io/github/vigoo/desert/ziosupport/Codecs.scala
@@ -4,7 +4,6 @@ import io.github.vigoo.desert._
 import io.github.vigoo.desert.ziosupport.custom._
 import io.github.vigoo.desert.BinaryCodec
 import io.github.vigoo.desert.custom._
-import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
 import zio.Chunk
 
 trait Codecs extends LowerPriorityCodecs {

--- a/desert-zio/src/main/scala/io/github/vigoo/desert/ziosupport/Codecs.scala
+++ b/desert-zio/src/main/scala/io/github/vigoo/desert/ziosupport/Codecs.scala
@@ -4,19 +4,20 @@ import io.github.vigoo.desert._
 import io.github.vigoo.desert.ziosupport.custom._
 import io.github.vigoo.desert.BinaryCodec
 import io.github.vigoo.desert.custom._
+import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
 import zio.Chunk
 
 trait Codecs extends LowerPriorityCodecs {
 
-  implicit val byteChunkCodec: BinaryCodec[Chunk[Byte]] = BinaryCodec.define[Chunk[Byte]](chunk =>
-    for {
-      _ <- writeVarInt(chunk.size, optimizeForPositive = true)
-      _ <- writeByteChunk(chunk)
-    } yield ()
-  )(
-    for {
-      size  <- readVarInt(optimizeForPositive = true)
-      chunk <- readByteChunk(size)
-    } yield chunk
-  )
+  implicit val byteChunkCodec: BinaryCodec[Chunk[Byte]] = new BinaryCodec[Chunk[Byte]] {
+    override def deserialize()(implicit ctx: DeserializationContext): Chunk[Byte] = {
+      val size = readVarInt(optimizeForPositive = true)
+      readByteChunk(size)
+    }
+
+    override def serialize(value: Chunk[Byte])(implicit context: SerializationContext): Unit = {
+      writeVarInt(value.size, optimizeForPositive = true)
+      writeByteChunk(value)
+    }
+  }
 }

--- a/desert-zio/src/main/scala/io/github/vigoo/desert/ziosupport/custom/package.scala
+++ b/desert-zio/src/main/scala/io/github/vigoo/desert/ziosupport/custom/package.scala
@@ -1,8 +1,7 @@
 package io.github.vigoo.desert.ziosupport
 
 import io.github.vigoo.desert._
-import io.github.vigoo.desert.custom.{readBytes, writeBytes}
-import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
+import io.github.vigoo.desert.custom.{DeserializationContext, SerializationContext, readBytes, writeBytes}
 import zio.Chunk
 
 package object custom {

--- a/desert-zio/src/main/scala/io/github/vigoo/desert/ziosupport/custom/package.scala
+++ b/desert-zio/src/main/scala/io/github/vigoo/desert/ziosupport/custom/package.scala
@@ -1,15 +1,14 @@
 package io.github.vigoo.desert.ziosupport
 
 import io.github.vigoo.desert._
-import io.github.vigoo.desert.custom.{getInput, getOutput}
+import io.github.vigoo.desert.custom.{readBytes, writeBytes}
+import io.github.vigoo.desert.internal.{DeserializationContext, SerializationContext}
 import zio.Chunk
 
 package object custom {
-  final def writeByteChunk[A](chunk: Chunk[Byte]): Ser[Unit] = getOutput.flatMap { output =>
-    Ser.fromEither(output.writeBytes(chunk.toArray))
-  }
+  final def writeByteChunk[A](chunk: Chunk[Byte])(implicit ctx: SerializationContext): Unit =
+    writeBytes(chunk.toArray)
 
-  final def readByteChunk[A](count: Int): Deser[Chunk[Byte]] = getInput.flatMap { input =>
-    Deser.fromEither(input.readBytes(count).map(Chunk.fromArray[Byte]))
-  }
+  final def readByteChunk[A](count: Int)(implicit ctx: DeserializationContext): Chunk[Byte] =
+    Chunk.fromArray(readBytes(count))
 }

--- a/docs/docs/docs/index.md
+++ b/docs/docs/docs/index.md
@@ -5,10 +5,11 @@ title: Getting started
 
 # Getting started with desert
 
-Desert is a _binary serialization library_ for Scala, focusing on creating small binaries 
+Desert is a _binary serialization library_ for Scala, focusing on creating small binaries
 while still enabling binary compatible evolution of the data model.
- 
-It is suitable for use cases such as Akka _remoting_ and _persistence_.
+
+It is suitable for use cases such as Akka _remoting_ and _persistence_, and for any kind
+of short or long term storage.
 
 First add `desert` as a dependency:
 
@@ -41,6 +42,7 @@ import io.github.vigoo.desert._
 
 val x = "Hello world"
 ```
+
 ```scala mdoc:serialized
 val dataOrFailure = serializeToArray(x)
 ```
@@ -54,20 +56,35 @@ val y = dataOrFailure.flatMap(data => deserializeFromArray[String](data))
 This works because there is an implicit `BinaryCodec` for `String` in scope, imported from the `desert` package. Read
 the [codecs page](codecs) to learn about the available codecs and how to define custom ones.
 
+#### Shapeless or ZIO Schema?
+
+The library has two derivation implementations. The _Shapeless_ based is the original one and is more mature, but
+only works with Scala 2. The ZIO Schema based derivation works both with Scala 2 and Scala 3 and it is planned to
+be the only available implementation in future versions.
+
+There are only small differences in using the two implementations:
+
+- For _Shapeless_ based derivation you have to define an implicit codec _for each constructor_ of a sealed trait
+- For _ZIO Schema_ based derivation you have to derive a `Schema` for each type as well
+
 ### Low level input/output
 
 The above example shows the convenient functions to work on arrays directly, but they have a more generic
-version working on the low level `BinaryInput` and `BinaryOutput` interfaces. These are described on the [input/output page](input-output). 
+version working on the low level `BinaryInput` and `BinaryOutput` interfaces. These are described on
+the [input/output page](input-output).
 
 ### Evolution
+
 One of the primary features of the library is the support for _evolving the data model_. The possibilities
 are described on a [separate page](evolution).
 
 ### Type registry
+
 For cases when the exact type to be deserialized is not known at compile type, the possibilities
- can be registered to a [type registry](type-registry).
+can be registered to a [type registry](type-registry).
 
 ### Integrations
+
 There are three additional modules providing integrations to different environments:
 
 - [Akka](akka) codecs and _Akka Serializer_ implementation

--- a/docs/docs/docs/input-output.md
+++ b/docs/docs/docs/input-output.md
@@ -32,11 +32,3 @@ stream.reset()
 output.writeVarInt(-1, optimizeForPositive = true)
 val r3 = stream.toByteArray
 ```
-
-### [Z]IO? 
-The read and write operations on these interfaces are not encapsulated to any effect type like Cats Effect's IO or ZIO,
-they are just `Either[DesertFailure, T]`. This is for performance reasons.
-
-On the other hand the [Cats Effect module](cats-effect) and the [ZIO module](zio) both define
-IO versions of the higher level serialization/deserialization functions. Usage of `desert` should be in low level
-enough to treat these operations as a single effect.

--- a/docs/docs/docs/release-notes.md
+++ b/docs/docs/docs/release-notes.md
@@ -12,6 +12,7 @@ title: Release notes
 - Shardcake module
 - Many new built-in codecs
 - Redesigned package structure
+- Lower level codec API in place of the ZPure one for higher performance 
 
 ## 0.2.3
 - Dependency updates, support for ZIO 2.0.0-RC6

--- a/project/TupleCodecGenerator.scala
+++ b/project/TupleCodecGenerator.scala
@@ -95,7 +95,7 @@ object TupleCodecGenerator extends AutoPlugin {
               deserializationCommands = List(
                 ..$deserializationCommands
               ),
-              new ${model.appliedBuilderInit},
+              () => new ${model.appliedBuilderInit},
               _.asTuple
             )
        """


### PR DESCRIPTION
old: 

```
[info] GenericComplexSerializationBenchmark.deserializeComplexDataStructure            N/A   34253      12  thrpt   25       0.081 ±   0.001  ops/ms
[info] GenericComplexSerializationBenchmark.serializeComplexDataStructure              N/A   34253      12  thrpt   25       0.094 ±   0.001  ops/ms
[info] JavaStreamBinaryInputBenchmark.readByte                                         N/A     N/A     N/A  thrpt   50   34317.703 ±  75.847  ops/ms
[info] JavaStreamBinaryInputBenchmark.readBytes                                        N/A     N/A     N/A  thrpt   50    1544.846 ±   4.471  ops/ms
[info] JavaStreamBinaryInputBenchmark.readDouble                                       N/A     N/A     N/A  thrpt   50   30458.934 ±  57.228  ops/ms
[info] JavaStreamBinaryInputBenchmark.readFloat                                        N/A     N/A     N/A  thrpt   50   18068.088 ±  80.951  ops/ms
[info] JavaStreamBinaryInputBenchmark.readInt                                          N/A     N/A     N/A  thrpt   50   17877.505 ±  70.633  ops/ms
[info] JavaStreamBinaryInputBenchmark.readLong                                         N/A     N/A     N/A  thrpt   50   30302.676 ±  60.778  ops/ms
[info] JavaStreamBinaryInputBenchmark.readShort                                        N/A     N/A     N/A  thrpt   50   27781.025 ±  47.899  ops/ms
[info] JavaStreamBinaryInputBenchmark.readVarInt                                       N/A     N/A     N/A  thrpt   50   31095.668 ± 162.525  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeByte                                       N/A     N/A     N/A  thrpt   50  101327.423 ± 438.228  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeBytes                                      N/A     N/A     N/A  thrpt   50     611.048 ±  16.563  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeDouble                                     N/A     N/A     N/A  thrpt   50   60591.642 ± 169.784  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeInt                                        N/A     N/A     N/A  thrpt   50   42407.368 ± 227.795  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeLong                                       N/A     N/A     N/A  thrpt   50   60202.621 ± 160.301  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeShort                                      N/A     N/A     N/A  thrpt   50   76707.602 ± 353.615  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeVarInt                                     N/A     N/A     N/A  thrpt   50   53722.409 ± 296.000  ops/ms
[info] LargeCompressedArraySerializationBenchmark.deserializeLargeCompressedArray        1     N/A     N/A  thrpt   50       1.025 ±   0.002  ops/ms
[info] LargeCompressedArraySerializationBenchmark.serializeLargeCompressedArray          1     N/A     N/A  thrpt   50       0.360 ±   0.001  ops/ms
```

new:

```
[info] GenericComplexSerializationBenchmark.deserializeComplexDataStructure            N/A   34253      12  thrpt   25       1.220 ±    0.013  ops/ms
[info] GenericComplexSerializationBenchmark.serializeComplexDataStructure              N/A   34253      12  thrpt   25       1.378 ±    0.008  ops/ms
[info] GenericComplexSerializationZioSchemaBenchmark.deserializeComplexDataStructure   N/A   34253      12  thrpt   25       0.859 ±   0.003  ops/ms
[info] GenericComplexSerializationZioSchemaBenchmark.serializeComplexDataStructure     N/A   34253      12  thrpt   25       1.107 ±   0.014  ops/ms
[info] JavaStreamBinaryInputBenchmark.readByte                                         N/A     N/A     N/A  thrpt   50   38876.851 ±  109.319  ops/ms
[info] JavaStreamBinaryInputBenchmark.readBytes                                        N/A     N/A     N/A  thrpt   50    1569.202 ±   11.880  ops/ms
[info] JavaStreamBinaryInputBenchmark.readDouble                                       N/A     N/A     N/A  thrpt   50   35824.478 ±  105.515  ops/ms
[info] JavaStreamBinaryInputBenchmark.readFloat                                        N/A     N/A     N/A  thrpt   50   19203.590 ±   21.651  ops/ms
[info] JavaStreamBinaryInputBenchmark.readInt                                          N/A     N/A     N/A  thrpt   50   19273.876 ±   23.784  ops/ms
[info] JavaStreamBinaryInputBenchmark.readLong                                         N/A     N/A     N/A  thrpt   50   35968.912 ±  128.084  ops/ms
[info] JavaStreamBinaryInputBenchmark.readShort                                        N/A     N/A     N/A  thrpt   50   29947.543 ±   54.189  ops/ms
[info] JavaStreamBinaryInputBenchmark.readVarInt                                       N/A     N/A     N/A  thrpt   50   41992.874 ±   68.635  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeByte                                       N/A     N/A     N/A  thrpt   50  100747.696 ± 1240.757  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeBytes                                      N/A     N/A     N/A  thrpt   50     633.550 ±    6.088  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeDouble                                     N/A     N/A     N/A  thrpt   50   63718.069 ±  835.505  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeInt                                        N/A     N/A     N/A  thrpt   50   42344.990 ±  763.297  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeLong                                       N/A     N/A     N/A  thrpt   50   68774.549 ±  151.205  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeShort                                      N/A     N/A     N/A  thrpt   50   87374.803 ±  144.227  ops/ms
[info] JavaStreamBinaryOutputBenchmark.writeVarInt                                     N/A     N/A     N/A  thrpt   50   52840.371 ±  295.112  ops/ms
[info] LargeCompressedArraySerializationBenchmark.deserializeLargeCompressedArray        1     N/A     N/A  thrpt   50       1.024 ±    0.003  ops/ms
[info] LargeCompressedArraySerializationBenchmark.serializeLargeCompressedArray          1     N/A     N/A  thrpt   50       0.365 ±    0.001  ops/ms
```