### PR TITLE
Fixes ignoring transient fields in zio-schema based ADT codecs

### DIFF
--- a/desert-core/src/main/scala/io/github/vigoo/desert/internal/AdtCodec.scala
+++ b/desert-core/src/main/scala/io/github/vigoo/desert/internal/AdtCodec.scala
@@ -396,7 +396,7 @@ object AdtCodec {
           }
         }
 
-        override def serialize(value: SerializedEvolutionStep)(implicit context: SerializationContext): Unit =
+        override def serialize(value: SerializedEvolutionStep)(implicit context: SerializationContext): Unit = {
           value match {
             case FieldAddedToNewChunk(size)  =>
               writeVarInt(size, optimizeForPositive = false)
@@ -409,6 +409,7 @@ object AdtCodec {
             case UnknownEvolutionStep        =>
               writeVarInt(Codes.Unknown, optimizeForPositive = false)
           }
+        }
       }
   }
 

--- a/desert-core/src/test/scala/io/github/vigoo/desert/PrimitiveSerializationSpec.scala
+++ b/desert-core/src/test/scala/io/github/vigoo/desert/PrimitiveSerializationSpec.scala
@@ -73,6 +73,14 @@ object PrimitiveSerializationSpec extends ZIOSpecDefault with SerializationPrope
       test("localDateTime")(canBeSerialized(Gen.localDateTime)),
       test("offsetTime")(canBeSerialized(Gen.offsetTime)),
       test("offsetDateTime")(canBeSerialized(Gen.offsetDateTime)),
-      test("zonedDateTime")(canBeSerialized(Gen.zonedDateTime))
+      test("zonedDateTime")(canBeSerialized(Gen.zonedDateTime)),
+      test("debug") {
+        val value        = -1
+        val serialized   = serializeToArray(value)(varIntCodec)
+        println(serialized.map(_.toList.map(_.toHexString)))
+        val deserialized = deserializeFromArray(serialized.toOption.get)(varIntCodec)
+        println(deserialized)
+        assertCompletes
+      }
     )
 }

--- a/desert-core/src/test/scala/io/github/vigoo/desert/PrimitiveSerializationSpec.scala
+++ b/desert-core/src/test/scala/io/github/vigoo/desert/PrimitiveSerializationSpec.scala
@@ -73,14 +73,6 @@ object PrimitiveSerializationSpec extends ZIOSpecDefault with SerializationPrope
       test("localDateTime")(canBeSerialized(Gen.localDateTime)),
       test("offsetTime")(canBeSerialized(Gen.offsetTime)),
       test("offsetDateTime")(canBeSerialized(Gen.offsetDateTime)),
-      test("zonedDateTime")(canBeSerialized(Gen.zonedDateTime)),
-      test("debug") {
-        val value        = -1
-        val serialized   = serializeToArray(value)(varIntCodec)
-        println(serialized.map(_.toList.map(_.toHexString)))
-        val deserialized = deserializeFromArray(serialized.toOption.get)(varIntCodec)
-        println(deserialized)
-        assertCompletes
-      }
+      test("zonedDateTime")(canBeSerialized(Gen.zonedDateTime))
     )
 }


### PR DESCRIPTION
Unfortunately the zio-schema based derived codecs for ADTs were not properly ignoring transient fields (fields marked with the `transientField` annotation). The original, shapeless based derivation is not affected by this.

I think any binary created by the faulty version can be read back by removing the `transientField` annotation from all the affected fields. If this is not the case please open an issue.